### PR TITLE
MOTR-256 README description for phenotypic data release

### DIFF
--- a/src/ReleasePage/releaseDescReadme.jsx
+++ b/src/ReleasePage/releaseDescReadme.jsx
@@ -5,7 +5,29 @@ import EmailLink from '../lib/ui/emailLink';
 
 function ReleaseDescReadme({ releaseVersion, fileLocation }) {
   if (releaseVersion === '1.2.1') {
-    return null;
+    return (
+      <p className="release-description">
+        A
+        {' '}
+        <a
+          href={fileLocation}
+          className="inline-link-with-icon"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          README
+          <i className="material-icons readme-file-icon">description</i>
+        </a>
+        {' '}
+        document has been provided summarizing the data available in this release. To
+        learn more about the prior released dataset, please see the
+        {' '}
+        <Link to="/announcements" className="inline-link">recent announcement</Link>
+        . For any technical issues, please contact us at
+        {' '}
+        <EmailLink mailto="motrpac-helpdesk@lists.stanford.edu" label="MoTrPAC Helpdesk" />
+      </p>
+    );
   }
 
   return (


### PR DESCRIPTION
### Key Changes:

Implemented the README description text that was pending for phenotypic data release.

---

### Steps to test:

1.  Sign into the portal and proceed to the ^/releases page.
2.  Expect to see the "A README document has been provided summarizing..." text paragraph present in the Release 1.2.1 description section.