### PR TITLE
MOTR-263 MoTrPAC Internal Release 2.0 UI Updates

### DIFF
--- a/src/AnnouncementsPage/announcements.json
+++ b/src/AnnouncementsPage/announcements.json
@@ -58,5 +58,28 @@
                 "url": "http://study-docs.motrpac-data.org/MoTrPAC_BIC_Data_hub_recorded_webinar.mp4"
             }
         ]
+    },
+    {
+        "aid": 1,
+        "posted_date": "2020-06-25",
+        "title": "First MoTrPAC paper published in the Cell journal",
+        "content": "The first MoTrPAC paper is now published in the Cell journal. This publication describes the entire MoTrPAC study. It includes the human endurance and resistance training interventions, and the extensive animal study protocols. It lists all the tissues collected and the analysis plan for those tissues. It also provides information on data dissemination, that will be done through the MoTrPAC data hub. Check it out so you know what is coming!",
+        "metadata": {
+            "target": "external",
+            "tags": [
+                "marker-paper"
+            ],
+            "icon": "menu_book"
+        },
+        "links": [
+            {
+                "label": "Cell journal publication",
+                "url": "https://grants.nih.gov/grants/guide/rfa-files/RFA-RM-20-009.html"
+            },
+            {
+                "label": "NIH press release",
+                "url": "http://study-docs.motrpac-data.org/MoTrPAC_BIC_Data_hub_webinar_slides.pdf"
+            }
+        ]
     }
 ]

--- a/src/AnnouncementsPage/announcements.json
+++ b/src/AnnouncementsPage/announcements.json
@@ -73,8 +73,8 @@
         },
         "links": [
             {
-                "label": "Cell journal publication",
-                "url": "https://grants.nih.gov/grants/guide/rfa-files/RFA-RM-20-009.html"
+                "label": "Molecular Transducers of Physical Activity Consortium (MoTrPAC): Mapping the Dynamic Responses to Exercise",
+                "url": "https://www.cell.com/cell/fulltext/S0092-8674(20)30691-7"
             },
             {
                 "label": "NIH press release",

--- a/src/AnnouncementsPage/announcements.json
+++ b/src/AnnouncementsPage/announcements.json
@@ -77,8 +77,8 @@
                 "url": "https://www.cell.com/cell/fulltext/S0092-8674(20)30691-7"
             },
             {
-                "label": "NIH press release",
-                "url": "https://commonfund.nih.gov/moleculartransducers"
+                "label": "NIH-funded study to recruit thousands of participants to reveal exercise impact at the molecular level",
+                "url": "https://www.nih.gov/news-events/news-releases/nih-funded-study-recruit-thousands-participants-reveal-exercise-impact-molecular-level"
             }
         ]
     }

--- a/src/AnnouncementsPage/announcements.json
+++ b/src/AnnouncementsPage/announcements.json
@@ -78,7 +78,7 @@
             },
             {
                 "label": "NIH press release",
-                "url": "http://study-docs.motrpac-data.org/MoTrPAC_BIC_Data_hub_webinar_slides.pdf"
+                "url": "https://commonfund.nih.gov/moleculartransducers"
             }
         ]
     }

--- a/src/AnnouncementsPage/announcements.json
+++ b/src/AnnouncementsPage/announcements.json
@@ -60,7 +60,7 @@
         ]
     },
     {
-        "aid": 1,
+        "aid": 4,
         "posted_date": "2020-06-25",
         "title": "First MoTrPAC paper published in the Cell journal",
         "content": "The first MoTrPAC paper is now published in the Cell journal. This publication describes the entire MoTrPAC study. It includes the human endurance and resistance training interventions, and the extensive animal study protocols. It lists all the tissues collected and the analysis plan for those tissues. It also provides information on data dissemination, that will be done through the MoTrPAC data hub. Check it out so you know what is coming!",

--- a/src/LandingPage/landingPage.jsx
+++ b/src/LandingPage/landingPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Redirect, Link } from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
 import Particles from 'react-particles-js';
 import { useSpring, animated } from 'react-spring';
 import LogoAnimation from '../assets/LandingPageGraphics/LogoAnimation_03082019-yellow_pipelineball_left.gif';
@@ -84,27 +84,24 @@ export function LandingPage({ isAuthenticated, profile }) {
     setVisibility(!visibility);
   }
 
-  // Function to render external data release notice
-  const ExternalDataReleaseNotice = () => (
-    <div className="alert alert-primary alert-dismissible fade show data-access-announce d-flex align-items-center justify-content-between w-100" role="alert">
-      <span className="data-access-announce-content">
-        <h6>
-          MoTrPAC data release 1.0 is now available! There is data from 5 different
-          tissues following an acute exercise bout in rats. Visit the
+  // Function to render marker paper announcement
+  const MarkerPaperNotice = () => (
+    <div className="alert alert-primary alert-dismissible fade show marker-paper-announce d-flex align-items-center justify-content-between w-100" role="alert">
+      <span className="marker-paper-announce-content">
+        <h5>
+          The
           {' '}
-          <Link to="/data-access" className="inline-link">Data Access</Link>
+          <ExternalLink to="https://www.cell.com/cell/home" label="first MoTrPAC paper" />
           {' '}
-          page to learn more and register for access.
-        </h6>
-        <h6>
-          <Link to="/announcements" className="inline-link">Find out more</Link>
+          is now published in the journal
           {' '}
-          about MoTrPAC's recent Pre-Application Webinar regarding a current
+          <i>Cell</i>
+          . Read the
           {' '}
-          <ExternalLink to="https://grants.nih.gov/grants/guide/rfa-files/RFA-RM-20-009.html" label="Funding Opportunity Announcement" />
+          <ExternalLink to="https://commonfund.nih.gov/moleculartransducers" label="NIH press release" />
           {' '}
-          and updates on known issues with the initial dataset.
-        </h6>
+          for further information about this publication.
+        </h5>
       </span>
       <button type="button" className="close" data-dismiss="alert" aria-label="Close">
         <span aria-hidden="true">&times;</span>
@@ -117,7 +114,7 @@ export function LandingPage({ isAuthenticated, profile }) {
       <main>
         <div className="container hero h-100">
           <div className="row hero-wrapper h-100">
-            <ExternalDataReleaseNotice />
+            <MarkerPaperNotice />
             <div className="hero-image col-12 col-md-8 mx-auto">
               <img src={LogoAnimation} className="img-fluid" alt="Data Layer Runner" />
             </div>

--- a/src/LandingPage/landingPage.jsx
+++ b/src/LandingPage/landingPage.jsx
@@ -91,7 +91,7 @@ export function LandingPage({ isAuthenticated, profile }) {
         <h5>
           The
           {' '}
-          <ExternalLink to="https://www.cell.com/cell/home" label="first MoTrPAC paper" />
+          <ExternalLink to="https://www.cell.com/cell/fulltext/S0092-8674(20)30691-7" label="first MoTrPAC paper" />
           {' '}
           is now published in the journal
           {' '}

--- a/src/LandingPage/landingPage.jsx
+++ b/src/LandingPage/landingPage.jsx
@@ -98,7 +98,7 @@ export function LandingPage({ isAuthenticated, profile }) {
           <i>Cell</i>
           . Read the
           {' '}
-          <ExternalLink to="https://commonfund.nih.gov/moleculartransducers" label="NIH press release" />
+          <ExternalLink to="https://www.nih.gov/news-events/news-releases/nih-funded-study-recruit-thousands-participants-reveal-exercise-impact-molecular-level" label="NIH press release" />
           {' '}
           for further information about this publication.
         </h5>

--- a/src/ReleasePage/ReleaseDataTables/releaseDataTableExternal.jsx
+++ b/src/ReleasePage/ReleaseDataTables/releaseDataTableExternal.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function ReleaseDataTableExternal({ release, renderDataTypeRow }) {
+  return (
+    <div className="release-data-links-table-container">
+      <table className="table table-sm release-data-links-table">
+        <thead className="thead-dark">
+          <tr className="table-head">
+            <th>Data type</th>
+            <th>Web download</th>
+          </tr>
+        </thead>
+        <tbody>
+          {release.result_files.data_types.map((item) => renderDataTypeRow(
+            release.result_files.bucket_name,
+            item,
+            release.version,
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+ReleaseDataTableExternal.propTypes = {
+  release: PropTypes.shape({
+    version: PropTypes.string,
+    result_files: PropTypes.object,
+  }).isRequired,
+  renderDataTypeRow: PropTypes.func.isRequired,
+};
+
+export default ReleaseDataTableExternal;

--- a/src/ReleasePage/ReleaseDataTables/releaseDataTableInternal.jsx
+++ b/src/ReleasePage/ReleaseDataTables/releaseDataTableInternal.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function ReleaseDataTableInternal({ release, renderDataTypeRow }) {
+  return (
+    <div className="release-data-links-table-container">
+      <table className="table table-sm release-data-links-table">
+        <thead className="thead-dark">
+          <tr className="table-head">
+            <th className="col-data-type">Data type</th>
+            <th className="col-command-line-download">Command-line download</th>
+            <th className="col-web-download">Web download</th>
+          </tr>
+        </thead>
+        <tbody>
+          {release.result_files.data_types.map((item) => renderDataTypeRow(
+            release.result_files.bucket_name,
+            item,
+            release.version,
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+ReleaseDataTableInternal.propTypes = {
+  release: PropTypes.shape({
+    version: PropTypes.string,
+    result_files: PropTypes.object,
+  }).isRequired,
+  renderDataTypeRow: PropTypes.func.isRequired,
+};
+
+export default ReleaseDataTableInternal;

--- a/src/ReleasePage/ReleaseDataTables/releaseDataTableInternalByPhase.jsx
+++ b/src/ReleasePage/ReleaseDataTables/releaseDataTableInternalByPhase.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function ReleaseDataTableInternalByPhase({ release, renderDataTypeRow }) {
+  return (
+    <div className="release-data-links-table-container">
+      <h6>Phase: PASS1A 6-month</h6>
+      <table className="table table-sm release-data-links-table">
+        <thead className="thead-dark">
+          <tr className="table-head">
+            <th className="col-data-type">Data type</th>
+            <th className="col-command-line-download">Command-line download</th>
+            <th className="col-web-download">Web download</th>
+          </tr>
+        </thead>
+        <tbody>
+          {release.result_files.data_types.pass1a_06.map((item) => renderDataTypeRow(
+            release.result_files.bucket_name,
+            item,
+            release.version,
+          ))}
+        </tbody>
+      </table>
+      <h6>Phase: PASS1B 6-month</h6>
+      <table className="table table-sm release-data-links-table">
+        <thead className="thead-dark">
+          <tr className="table-head">
+            <th className="col-data-type">Data type</th>
+            <th className="col-command-line-download">Command-line download</th>
+            <th className="col-web-download">Web download</th>
+          </tr>
+        </thead>
+        <tbody>
+          {release.result_files.data_types.pass1b_06.map((item) => renderDataTypeRow(
+            release.result_files.bucket_name,
+            item,
+            release.version,
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+ReleaseDataTableInternalByPhase.propTypes = {
+  release: PropTypes.shape({
+    version: PropTypes.string,
+    result_files: PropTypes.object,
+  }).isRequired,
+  renderDataTypeRow: PropTypes.func.isRequired,
+};
+
+export default ReleaseDataTableInternalByPhase;

--- a/src/ReleasePage/releaseDescReadme.jsx
+++ b/src/ReleasePage/releaseDescReadme.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import EmailLink from '../lib/ui/emailLink';
 
 function ReleaseDescReadme({ releaseVersion, fileLocation }) {
-  if (releaseVersion === '1.2.1') {
+  if (releaseVersion === '1.2.1' || releaseVersion === '2.0') {
     return (
       <p className="release-description">
         A

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -8,6 +8,10 @@ import ExternalLink from '../lib/ui/externalLink';
 import StudyDocumentsTable from '../lib/studyDocumentsTable';
 import ReleaseDescFileExtract from './releaseDescFileExtract';
 import ReleaseDescReadme from './releaseDescReadme';
+import ReleaseRawFilesDownload from './releaseRawFilesDownload';
+import ReleaseDataTableInternalByPhase from './ReleaseDataTables/releaseDataTableInternalByPhase';
+import ReleaseDataTableInternal from './ReleaseDataTables/releaseDataTableInternal';
+import ReleaseDataTableExternal from './ReleaseDataTables/releaseDataTableExternal';
 
 const releaseData = require('./releases');
 
@@ -57,35 +61,6 @@ function ReleaseEntry({ profile, currentView }) {
       el.classList.add('active');
       el.innerHTML = 'check_box';
     }
-  }
-
-  // Render raw files download section content
-  function renderRawFilesDownloadSectionContent(files) {
-    return (
-      <div className="card mb-3">
-        <div className="card-body">
-          <p className="card-text">
-            Due to the large sizes of raw data files, we recommend users
-            who wish to download raw data files using the
-            {' '}
-            <ExternalLink to="https://cloud.google.com/storage/docs/quickstart-gsutil" label="gsutil command" />
-            . Below are example commands for downloading raw data files of different omics.
-          </p>
-          <p className="card-text">
-            Raw data files of genomics, epigenomics and transcriptomic:
-            <code>{`gsutil -m cp -r gs://${files.get.bucket_name}/* .`}</code>
-          </p>
-          <p className="card-text">
-            Raw data files of metabolomics:
-            <code>{`gsutil -m cp -r gs://${files.metabolomics.bucket_name}/* .`}</code>
-          </p>
-          <p className="card-text">
-            Raw data files of proteomics:
-            <code>{`gsutil -m cp -r gs://${files.proteomics.bucket_name}/* .`}</code>
-          </p>
-        </div>
-      </div>
-    );
   }
 
   // Render intermediate files download section content
@@ -314,26 +289,24 @@ function ReleaseEntry({ profile, currentView }) {
                         releaseVersion={release.version}
                         fileLocation={release.readme_file_location}
                       />
-                      <div className="release-data-links-table-container">
-                        <table className="table table-sm release-data-links-table">
-                          <thead className="thead-dark">
-                            <tr className="table-head">
-                              <th>Data type</th>
-                              {currentView === 'internal'
-                                ? (<th>Command-line download</th>)
-                                : null}
-                              <th>Web download</th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {release.result_files.data_types.map((item) => renderDataTypeRow(
-                              release.result_files.bucket_name,
-                              item,
-                              release.version,
-                            ))}
-                          </tbody>
-                        </table>
-                      </div>
+                      {currentView === 'internal' && release.version === '2.0' ? (
+                        <ReleaseDataTableInternalByPhase
+                          release={release}
+                          renderDataTypeRow={renderDataTypeRow}
+                        />
+                      ) : null}
+                      {currentView === 'internal' && release.version.match(/1.0|1.1|1.2|1.2.1/g) ? (
+                        <ReleaseDataTableInternal
+                          release={release}
+                          renderDataTypeRow={renderDataTypeRow}
+                        />
+                      ) : null}
+                      {currentView === 'external' && release.version === '1.0' ? (
+                        <ReleaseDataTableExternal
+                          release={release}
+                          renderDataTypeRow={renderDataTypeRow}
+                        />
+                      ) : null}
                       {renderModal(release.version)}
                     </div>
                   </div>
@@ -357,36 +330,46 @@ function ReleaseEntry({ profile, currentView }) {
                             >
                               check_box_outline_blank
                             </i>
-                            <span>Raw files downloads</span>
+                            <span>
+                              Raw
+                              {release.version.match(/1.0|1.1|1.2|1.2.1/g) ? null : ' and intermediate'}
+                              {' '}
+                              files downloads
+                            </span>
                           </p>
                           <div className="collapse" id={`raw-files-release-${idx}`}>
-                            {renderRawFilesDownloadSectionContent(release.raw_files)}
+                            <ReleaseRawFilesDownload
+                              releaseVersion={release.version}
+                              files={release.raw_files}
+                            />
                           </div>
                         </div>
-                        <div className="intermediate-files-download-section">
-                          <p className="d-block mb-2 d-flex align-items-center justify-content-start intermediate-files-download-option">
-                            {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
-                            <i
-                              role="button"
-                              tabIndex="-1"
-                              className="material-icons download-checkbox"
-                              data-toggle="collapse"
-                              data-target={`#intermediate-files-release-${idx}`}
-                              aria-expanded="false"
-                              aria-controls={`intermediate-files-release-${idx}`}
-                              id={`intermediate-files-release-${idx}-checkbox`}
-                              onClick={handleCheckboxEvent.bind(this, `intermediate-files-release-${idx}-checkbox`)}
-                            >
-                              check_box_outline_blank
-                            </i>
-                            <span>Intermediate files downloads</span>
-                          </p>
-                          <div className="collapse" id={`intermediate-files-release-${idx}`}>
-                            {renderIntermediateFilesDownloadSectionContent(
-                              release.intermediate_files,
-                            )}
+                        {release.version.match(/1.0|1.1|1.2|1.2.1/g) && (
+                          <div className="intermediate-files-download-section">
+                            <p className="d-block mb-2 d-flex align-items-center justify-content-start intermediate-files-download-option">
+                              {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
+                              <i
+                                role="button"
+                                tabIndex="-1"
+                                className="material-icons download-checkbox"
+                                data-toggle="collapse"
+                                data-target={`#intermediate-files-release-${idx}`}
+                                aria-expanded="false"
+                                aria-controls={`intermediate-files-release-${idx}`}
+                                id={`intermediate-files-release-${idx}-checkbox`}
+                                onClick={handleCheckboxEvent.bind(this, `intermediate-files-release-${idx}-checkbox`)}
+                              >
+                                check_box_outline_blank
+                              </i>
+                              <span>Intermediate files downloads</span>
+                            </p>
+                            <div className="collapse" id={`intermediate-files-release-${idx}`}>
+                              {renderIntermediateFilesDownloadSectionContent(
+                                release.intermediate_files,
+                              )}
+                            </div>
                           </div>
-                        </div>
+                        )}
                       </>
                     )
                     : null}

--- a/src/ReleasePage/releaseRawFilesDownload.jsx
+++ b/src/ReleasePage/releaseRawFilesDownload.jsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ExternalLink from '../lib/ui/externalLink';
+
+function ReleaseRawFilesDownload({ releaseVersion, files }) {
+  if (releaseVersion.match(/1.0|1.1|1.2|1.2.1/g)) {
+    return (
+      <div className="card mb-3">
+        <div className="card-body">
+          <p className="card-text">
+            Due to the large sizes of raw data files, we recommend users
+            who wish to download raw data files using the
+            {' '}
+            <ExternalLink to="https://cloud.google.com/storage/docs/quickstart-gsutil" label="gsutil command" />
+            . Below are example commands for downloading raw data files of different omics.
+          </p>
+          <p className="card-text">
+            Raw data files of genomics, epigenomics and transcriptomic:
+            <code>{`gsutil -m cp -r gs://${files.get.bucket_name}/* .`}</code>
+          </p>
+          <p className="card-text">
+            Raw data files of metabolomics:
+            <code>{`gsutil -m cp -r gs://${files.metabolomics.bucket_name}/* .`}</code>
+          </p>
+          <p className="card-text">
+            Raw data files of proteomics:
+            <code>{`gsutil -m cp -r gs://${files.proteomics.bucket_name}/* .`}</code>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card mb-3">
+      <div className="card-body">
+        <p className="card-text">
+          Due to the large sizes of raw data files, we recommend users
+          who wish to download raw data files using the
+          {' '}
+          <ExternalLink to="https://cloud.google.com/storage/docs/quickstart-gsutil" label="gsutil command" />
+          . Below are example commands for downloading raw data files of different omics.
+        </p>
+        <div className="additional-download-table-container">
+          <h6>Phase: PASS1A 6-month</h6>
+          <table className="table table-sm additional-download-table">
+            <tbody>
+              <tr>
+                <td>Transcriptomics</td>
+                <td>
+                  <code>{`gsutil -m cp -r gs://${files.transcriptomics.bucket_name}/pass1a-06/* .`}</code>
+                </td>
+              </tr>
+              <tr>
+                <td>Epigenomics</td>
+                <td>
+                  <code>{`gsutil -m cp -r gs://${files.epigenomics.bucket_name}/pass1a-06/* .`}</code>
+                </td>
+              </tr>
+              <tr>
+                <td>Metabolomics-targeted</td>
+                <td>
+                  <code>{`gsutil -m cp -r gs://${files.metabolomics_targeted.bucket_name}/pass1a-06/* .`}</code>
+                </td>
+              </tr>
+              <tr>
+                <td>Metabolomics-untargeted</td>
+                <td>
+                  <code>{`gsutil -m cp -r gs://${files.metabolomics_untargeted.bucket_name}/pass1a-06/* .`}</code>
+                </td>
+              </tr>
+              <tr>
+                <td>Proteomics</td>
+                <td>
+                  <code>{`gsutil -m cp -r gs://${files.proteomics.bucket_name}/pass1a-06/* .`}</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h6>Phase: PASS1B 6-month</h6>
+          <table className="table table-sm additional-download-table">
+            <tbody>
+              <tr>
+                <td>Transcriptomics</td>
+                <td>
+                  <code>{`gsutil -m cp -r gs://${files.transcriptomics.bucket_name}/pass1b-06/* .`}</code>
+                </td>
+              </tr>
+              <tr>
+                <td>Epigenomics</td>
+                <td>
+                  <code>{`gsutil -m cp -r gs://${files.epigenomics.bucket_name}/pass1b-06/* .`}</code>
+                </td>
+              </tr>
+              <tr>
+                <td>Metabolomics-targeted</td>
+                <td>
+                  <code>{`gsutil -m cp -r gs://${files.metabolomics_targeted.bucket_name}/pass1b-06/* .`}</code>
+                </td>
+              </tr>
+              <tr>
+                <td>Metabolomics-untargeted</td>
+                <td>
+                  <code>{`gsutil -m cp -r gs://${files.metabolomics_untargeted.bucket_name}/pass1b-06/* .`}</code>
+                </td>
+              </tr>
+              <tr>
+                <td>Proteomics</td>
+                <td>
+                  <code>{`gsutil -m cp -r gs://${files.proteomics.bucket_name}/pass1b-06/* .`}</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReleaseRawFilesDownload.propTypes = {
+  releaseVersion: PropTypes.string.isRequired,
+  files: PropTypes.shape({
+    get: PropTypes.shape({ bucket_name: PropTypes.string }),
+    transcriptomics: PropTypes.shape({ bucket_name: PropTypes.string }),
+    epigenomics: PropTypes.shape({ bucket_name: PropTypes.string }),
+    metabolomics: PropTypes.shape({ bucket_name: PropTypes.string }),
+    metabolomics_targeted: PropTypes.shape({ bucket_name: PropTypes.string }),
+    metabolomics_untargeted: PropTypes.shape({ bucket_name: PropTypes.string }),
+    proteomics: PropTypes.shape({ bucket_name: PropTypes.string }),
+  }).isRequired,
+};
+
+export default ReleaseRawFilesDownload;

--- a/src/ReleasePage/releases.json
+++ b/src/ReleasePage/releases.json
@@ -6,7 +6,7 @@
     "date": "June 30, 2020",
     "target": "internal",
     "description": "The second major internal data release is now available through the MoTrPAC data hub. This release includes the majority of the PASS1A and PASS1B molecular and phenotypic data. Processed data is available for Web download and through the command-line, while raw data is available through the command-line only.",
-    "readme_file_location": "https://docs.google.com/document/d/1l-RtUNQr-FtC0aYe6rUXgJb_i5ZeWQiLp9nEjCl0QOk/",
+    "readme_file_location": "https://docs.google.com/document/d/1bdXcYQLZ65GpJKTjf9XwRxhrfHJSD9NIqCxhG6icL8U",
     "result_files": {
       "bucket_name": "motrpac-internal-release2-results",
       "data_types": {
@@ -19,7 +19,7 @@
             "tooltip_id": "data-pass1a-06-transcriptomics-int-2-0",
             "object_path": "/pass1a-06/transcriptomics",
             "object_zipfile_path": "/pass1a-06/transcriptomics.tar.gz",
-            "object_zipfile_size": "53 MB"
+            "object_zipfile_size": "250 MB"
           },
           {
             "type": "epigenomics",
@@ -29,7 +29,7 @@
             "tooltip_id": "data-pass1a-06-epigenomics-int-2-0",
             "object_path": "/pass1a-06/epigenomics",
             "object_zipfile_path": "/pass1a-06/epigenomics.tar.gz",
-            "object_zipfile_size": "21.56 GB"
+            "object_zipfile_size": "? GB"
           },
           {
             "type": "metabolomics-targeted",
@@ -39,7 +39,7 @@
             "tooltip_id": "data-pass1a-06-metabolomics-targeted-int-2-0",
             "object_path": "/pass1a-06/metabolomics-targeted",
             "object_zipfile_path": "/pass1a-06/metabolomics-targeted.tar.gz",
-            "object_zipfile_size": "23 MB"
+            "object_zipfile_size": "14.45 MB"
           },
           {
             "type": "metabolomics-untargeted",
@@ -49,7 +49,7 @@
             "tooltip_id": "data-pass1a-06-metabolomics-untargeted-int-2-0",
             "object_path": "/pass1a-06/metabolomics-untargeted",
             "object_zipfile_path": "/pass1a-06/metabolomics-untargeted.tar.gz",
-            "object_zipfile_size": "101 MB"
+            "object_zipfile_size": "199 MB"
           },
           {
             "type": "proteomics",
@@ -59,7 +59,7 @@
             "tooltip_id": "data-pass1a-06-proteomics-int-2-0",
             "object_path": "/pass1a-06/proteomics",
             "object_zipfile_path": "/pass1a-06/proteomics.tar.gz",
-            "object_zipfile_size": "298 MB"
+            "object_zipfile_size": "288 MB"
           },
           {
             "type": "phenotype",
@@ -69,7 +69,7 @@
             "tooltip_id": "data-pass1a-06-phenotype-int-2-0",
             "object_path": "/pass1a-06/phenotype",
             "object_zipfile_path": "/pass1a-06/phenotype.tar.gz",
-            "object_zipfile_size": "526 KB"
+            "object_zipfile_size": "? MB"
           },
           {
             "type": "all",
@@ -79,7 +79,7 @@
             "tooltip_id": "data-pass1a-06-all-int-2-0",
             "object_path": "/pass1a-06/all.tar.gz",
             "object_zipfile_path": "/pass1a-06/all.tar.gz",
-            "object_zipfile_size": "9 GB"
+            "object_zipfile_size": "? GB"
           }
         ],
         "pass1b_06": [
@@ -91,7 +91,7 @@
             "tooltip_id": "data-pass1b-06-transcriptomics-int-2-0",
             "object_path": "/pass1b-06/transcriptomics",
             "object_zipfile_path": "/pass1b-06/transcriptomics.tar.gz",
-            "object_zipfile_size": "53 MB"
+            "object_zipfile_size": "162.55 MB"
           },
           {
             "type": "epigenomics",
@@ -101,7 +101,7 @@
             "tooltip_id": "data-pass1b-06-epigenomics-int-2-0",
             "object_path": "/pass1b-06/epigenomics",
             "object_zipfile_path": "/pass1b-06/epigenomics.tar.gz",
-            "object_zipfile_size": "10.68 GB"
+            "object_zipfile_size": "? GB"
           },
           {
             "type": "metabolomics-targeted",
@@ -111,7 +111,7 @@
             "tooltip_id": "data-pass1b-06-metabolomics-targeted-int-2-0",
             "object_path": "/pass1b-06/metabolomics-targeted",
             "object_zipfile_path": "/pass1b-06/metabolomics-targeted.tar.gz",
-            "object_zipfile_size": "23 MB"
+            "object_zipfile_size": "1.5 MB"
           },
           {
             "type": "metabolomics-untargeted",
@@ -121,7 +121,7 @@
             "tooltip_id": "data-pass1b-06-metabolomics-untargeted-int-2-0",
             "object_path": "/pass1b-06/metabolomics-untargeted",
             "object_zipfile_path": "/pass1b-06/metabolomics-untargeted.tar.gz",
-            "object_zipfile_size": "101 MB"
+            "object_zipfile_size": "246.8 MB"
           },
           {
             "type": "proteomics",
@@ -131,7 +131,7 @@
             "tooltip_id": "data-pass1b-06-proteomics-int-2-0",
             "object_path": "/pass1b-06/proteomics",
             "object_zipfile_path": "/pass1b-06/proteomics.tar.gz",
-            "object_zipfile_size": "298 MB"
+            "object_zipfile_size": "278.8 MB"
           },
           {
             "type": "phenotype",
@@ -141,7 +141,7 @@
             "tooltip_id": "data-pass1b-06-phenotype-int-2-0",
             "object_path": "/pass1b-06/phenotype",
             "object_zipfile_path": "/pass1b-06/phenotype.tar.gz",
-            "object_zipfile_size": "526 KB"
+            "object_zipfile_size": "? MB"
           },
           {
             "type": "all",
@@ -151,7 +151,7 @@
             "tooltip_id": "data-pass1b-06-all-int-2-0",
             "object_path": "/pass1b-06/all.tar.gz",
             "object_zipfile_path": "/pass1b-06/all.tar.gz",
-            "object_zipfile_size": "9 GB"
+            "object_zipfile_size": "? GB"
           }
         ]
       }

--- a/src/ReleasePage/releases.json
+++ b/src/ReleasePage/releases.json
@@ -29,7 +29,7 @@
             "tooltip_id": "data-pass1a-06-epigenomics-int-2-0",
             "object_path": "/pass1a-06/epigenomics",
             "object_zipfile_path": "/pass1a-06/epigenomics.tar.gz",
-            "object_zipfile_size": "4.8 GB"
+            "object_zipfile_size": "412 MB"
           },
           {
             "type": "metabolomics-targeted",
@@ -101,7 +101,7 @@
             "tooltip_id": "data-pass1b-06-epigenomics-int-2-0",
             "object_path": "/pass1b-06/epigenomics",
             "object_zipfile_path": "/pass1b-06/epigenomics.tar.gz",
-            "object_zipfile_size": "2.31 GB"
+            "object_zipfile_size": "14 MB"
           },
           {
             "type": "metabolomics-targeted",

--- a/src/ReleasePage/releases.json
+++ b/src/ReleasePage/releases.json
@@ -29,7 +29,7 @@
             "tooltip_id": "data-pass1a-06-epigenomics-int-2-0",
             "object_path": "/pass1a-06/epigenomics",
             "object_zipfile_path": "/pass1a-06/epigenomics.tar.gz",
-            "object_zipfile_size": "? GB"
+            "object_zipfile_size": "4.8 GB"
           },
           {
             "type": "metabolomics-targeted",
@@ -101,7 +101,7 @@
             "tooltip_id": "data-pass1b-06-epigenomics-int-2-0",
             "object_path": "/pass1b-06/epigenomics",
             "object_zipfile_path": "/pass1b-06/epigenomics.tar.gz",
-            "object_zipfile_size": "? GB"
+            "object_zipfile_size": "2.31 GB"
           },
           {
             "type": "metabolomics-targeted",

--- a/src/ReleasePage/releases.json
+++ b/src/ReleasePage/releases.json
@@ -1,5 +1,181 @@
 [
   {
+    "label": "Release 2.0",
+    "emoji": "rocket",
+    "version": "2.0",
+    "date": "June 30, 2020",
+    "target": "internal",
+    "description": "The second major internal data release is now available through the MoTrPAC data hub. This release includes the majority of the PASS1A and PASS1B molecular and phenotypic data. Processed data is available for Web download and through the command-line, while raw data is available through the command-line only.",
+    "readme_file_location": "https://docs.google.com/document/d/1l-RtUNQr-FtC0aYe6rUXgJb_i5ZeWQiLp9nEjCl0QOk/",
+    "result_files": {
+      "bucket_name": "motrpac-internal-release2-results",
+      "data_types": {
+        "pass1a_06": [
+          {
+            "type": "transcriptomics",
+            "title": "Transcriptomics data (metadata, QC and quantitative results)",
+            "icon": "DNA",
+            "icon_alt": "Transcriptomics",
+            "tooltip_id": "data-pass1a-06-transcriptomics-int-2-0",
+            "object_path": "/pass1a-06/transcriptomics",
+            "object_zipfile_path": "/pass1a-06/transcriptomics.tar.gz",
+            "object_zipfile_size": "53 MB"
+          },
+          {
+            "type": "epigenomics",
+            "title": "Epigenomics data (RRBS and ATAC-seq metadata, QC and quantitative results)",
+            "icon": "DNA",
+            "icon_alt": "Epigenomics",
+            "tooltip_id": "data-pass1a-06-epigenomics-int-2-0",
+            "object_path": "/pass1a-06/epigenomics",
+            "object_zipfile_path": "/pass1a-06/epigenomics.tar.gz",
+            "object_zipfile_size": "21.56 GB"
+          },
+          {
+            "type": "metabolomics-targeted",
+            "title": "Metabolomics Targeted data (metadata, QC and quantitative results)",
+            "icon": "Metabolite",
+            "icon_alt": "Metabolomics Targeted",
+            "tooltip_id": "data-pass1a-06-metabolomics-targeted-int-2-0",
+            "object_path": "/pass1a-06/metabolomics-targeted",
+            "object_zipfile_path": "/pass1a-06/metabolomics-targeted.tar.gz",
+            "object_zipfile_size": "23 MB"
+          },
+          {
+            "type": "metabolomics-untargeted",
+            "title": "Metabolomics Untargeted data (metadata, QC and quantitative results)",
+            "icon": "Metabolite",
+            "icon_alt": "Metabolomics Untargeted",
+            "tooltip_id": "data-pass1a-06-metabolomics-untargeted-int-2-0",
+            "object_path": "/pass1a-06/metabolomics-untargeted",
+            "object_zipfile_path": "/pass1a-06/metabolomics-untargeted.tar.gz",
+            "object_zipfile_size": "101 MB"
+          },
+          {
+            "type": "proteomics",
+            "title": "Proteomics data (metadata, QC and quantitative results)",
+            "icon": "Protein",
+            "icon_alt": "Proteomic",
+            "tooltip_id": "data-pass1a-06-proteomics-int-2-0",
+            "object_path": "/pass1a-06/proteomics",
+            "object_zipfile_path": "/pass1a-06/proteomics.tar.gz",
+            "object_zipfile_size": "298 MB"
+          },
+          {
+            "type": "phenotype",
+            "title": "Phenotypic data",
+            "icon": "Gender",
+            "icon_alt": "Phenotypic",
+            "tooltip_id": "data-pass1a-06-phenotype-int-2-0",
+            "object_path": "/pass1a-06/phenotype",
+            "object_zipfile_path": "/pass1a-06/phenotype.tar.gz",
+            "object_zipfile_size": "526 KB"
+          },
+          {
+            "type": "all",
+            "title": "All of the omics and phenotypic data",
+            "icon": "Globe",
+            "icon_alt": "All omics",
+            "tooltip_id": "data-pass1a-06-all-int-2-0",
+            "object_path": "/pass1a-06/all.tar.gz",
+            "object_zipfile_path": "/pass1a-06/all.tar.gz",
+            "object_zipfile_size": "9 GB"
+          }
+        ],
+        "pass1b_06": [
+          {
+            "type": "transcriptomics",
+            "title": "Transcriptomics data (metadata, QC and quantitative results)",
+            "icon": "DNA",
+            "icon_alt": "Transcriptomics",
+            "tooltip_id": "data-pass1b-06-transcriptomics-int-2-0",
+            "object_path": "/pass1b-06/transcriptomics",
+            "object_zipfile_path": "/pass1b-06/transcriptomics.tar.gz",
+            "object_zipfile_size": "53 MB"
+          },
+          {
+            "type": "epigenomics",
+            "title": "Epigenomics data (RRBS and ATAC-seq metadata, QC and quantitative results)",
+            "icon": "DNA",
+            "icon_alt": "Epigenomics",
+            "tooltip_id": "data-pass1b-06-epigenomics-int-2-0",
+            "object_path": "/pass1b-06/epigenomics",
+            "object_zipfile_path": "/pass1b-06/epigenomics.tar.gz",
+            "object_zipfile_size": "10.68 GB"
+          },
+          {
+            "type": "metabolomics-targeted",
+            "title": "Metabolomics Targeted data (metadata, QC and quantitative results)",
+            "icon": "Metabolite",
+            "icon_alt": "Metabolomics Targeted",
+            "tooltip_id": "data-pass1b-06-metabolomics-targeted-int-2-0",
+            "object_path": "/pass1b-06/metabolomics-targeted",
+            "object_zipfile_path": "/pass1b-06/metabolomics-targeted.tar.gz",
+            "object_zipfile_size": "23 MB"
+          },
+          {
+            "type": "metabolomics-untargeted",
+            "title": "Metabolomics Untargeted data (metadata, QC and quantitative results)",
+            "icon": "Metabolite",
+            "icon_alt": "Metabolomics Untargeted",
+            "tooltip_id": "data-pass1b-06-metabolomics-untargeted-int-2-0",
+            "object_path": "/pass1b-06/metabolomics-untargeted",
+            "object_zipfile_path": "/pass1b-06/metabolomics-untargeted.tar.gz",
+            "object_zipfile_size": "101 MB"
+          },
+          {
+            "type": "proteomics",
+            "title": "Proteomics data (metadata, QC and quantitative results)",
+            "icon": "Protein",
+            "icon_alt": "Proteomic",
+            "tooltip_id": "data-pass1b-06-proteomics-int-2-0",
+            "object_path": "/pass1b-06/proteomics",
+            "object_zipfile_path": "/pass1b-06/proteomics.tar.gz",
+            "object_zipfile_size": "298 MB"
+          },
+          {
+            "type": "phenotype",
+            "title": "Phenotypic data",
+            "icon": "Gender",
+            "icon_alt": "Phenotypic",
+            "tooltip_id": "data-pass1b-06-phenotype-int-2-0",
+            "object_path": "/pass1b-06/phenotype",
+            "object_zipfile_path": "/pass1b-06/phenotype.tar.gz",
+            "object_zipfile_size": "526 KB"
+          },
+          {
+            "type": "all",
+            "title": "All of the omics and phenotypic data",
+            "icon": "Globe",
+            "icon_alt": "All omics",
+            "tooltip_id": "data-pass1b-06-all-int-2-0",
+            "object_path": "/pass1b-06/all.tar.gz",
+            "object_zipfile_path": "/pass1b-06/all.tar.gz",
+            "object_zipfile_size": "9 GB"
+          }
+        ]
+      }
+    },
+    "raw_files": {
+      "epigenomics": {
+        "bucket_name": "motrpac-internal-release2-raw-epigenomics"
+      },
+      "transcriptomics": {
+        "bucket_name": "motrpac-internal-release2-raw-transcriptomics"
+      },
+      "metabolomics_targeted": {
+        "bucket_name": "motrpac-internal-release2-raw-metabolomics-targeted"
+      },
+      "metabolomics_untargeted": {
+        "bucket_name": "motrpac-internal-release2-raw-metabolomics-untargeted"
+      },
+      "proteomics": {
+        "bucket_name": "motrpac-internal-release2-raw-proteomics"
+      }
+    },
+    "documentation": true
+  },
+  {
     "label": "Release 1.2.1",
     "emoji": "tada",
     "version": "1.2.1",
@@ -221,7 +397,7 @@
         "bucket_name": "motrpac-internal-release1-intermediate-proteomics"
       }
     },
-    "documentation": true
+    "documentation": false
   },
   {
     "label": "Release 1.1",

--- a/src/sass/_announcementsPage.scss
+++ b/src/sass/_announcementsPage.scss
@@ -36,6 +36,10 @@
     &.release {
       color: $stanford-bright-red;
     }
+
+    &.marker-paper {
+      color: $primary-blue;
+    }
   }
 
   .announcement-header {

--- a/src/sass/_landingPage.scss
+++ b/src/sass/_landingPage.scss
@@ -32,24 +32,33 @@ main {
       }
     }
 
-    .data-access-announce {
+    .marker-paper-announce {
+      border-radius: 0.35rem;
       margin-bottom: 0;
+      background: rgb(15,133,218);
+      background: linear-gradient(360deg, rgba(15,133,218,1) 0%, rgba(73,166,233,1) 100%);
 
-      .data-access-announce-content {
-        h6 {
+      .marker-paper-announce-content {
+        h5 {
+          color: #fff;
           font-weight: 600;
           line-height: 1.6;
           margin-top: 0.25rem;
-          margin-bottom: 0.6rem;
+          margin-bottom: 0.4rem;
+
+          a {
+            color: $accent-yellow;
+          
+            &:hover {
+              color: $accent-yellow-shade-medium;
+              text-decoration: none;
+            }
+          }
 
           .inline-link-with-icon .material-icons {
-            font-size: 1.25rem;
+            font-size: 1.6rem;
             margin-top: 0.2rem;
           }
-        }
-
-        h6:last-child {
-          margin-bottom: 0.25rem;
         }
       }
     }

--- a/src/sass/dataRelease/_releasePage.scss
+++ b/src/sass/dataRelease/_releasePage.scss
@@ -85,12 +85,12 @@
             vertical-align: middle;
 
             &.col-data-type {
-              width: 60%,
+              width: 50%,
             }
 
             &.col-command-line-download,
             &.col-web-download {
-              width: 20%,
+              width: 25%,
             }
           }
 

--- a/src/sass/dataRelease/_releasePage.scss
+++ b/src/sass/dataRelease/_releasePage.scss
@@ -52,6 +52,21 @@
       .card {
         border-color: $gray-semi-transparent;
 
+        table.additional-download-table {
+          font-size: 0.85rem;
+          margin-bottom: 0;
+
+          td {
+            padding: 0.55rem 0.75rem 0.55rem 0;
+          }
+        }
+
+        .release-data-links-table-container {
+          h6 {
+            margin-top: 1.25rem;
+          }
+        }
+
         table.release-data-links-table {
           border-collapse: collapse;
           font-size: 0.85rem;
@@ -62,6 +77,15 @@
             border: 1px solid #343a40;
             padding: 0.55rem 0.75rem;
             vertical-align: middle;
+
+            &.col-data-type {
+              width: 60%,
+            }
+
+            &.col-command-line-download,
+            &.col-web-download {
+              width: 20%,
+            }
           }
 
           td {
@@ -311,7 +335,8 @@
 
 @include media-breakpoint-down(sm) {
   .dataReleasePage {
-    .release-data-links-table-container {
+    .release-data-links-table-container,
+    .additional-download-table-container {
       border: 0;
       box-shadow: inset 0 0 0 1px #dee2e6;
       box-sizing: border-box;

--- a/src/sass/dataRelease/_releasePage.scss
+++ b/src/sass/dataRelease/_releasePage.scss
@@ -110,7 +110,9 @@
               line-height: 0;
 
               .copy-to-clipboard-wrapper {
+                margin: 0 auto;
                 position: relative;
+                width: 30px;
 
                 .copy-to-clipboard-button {
                   color: $primary-blue;

--- a/src/sass/dataRelease/_releasePage.scss
+++ b/src/sass/dataRelease/_releasePage.scss
@@ -53,16 +53,22 @@
         border-color: $gray-semi-transparent;
 
         table.additional-download-table {
+          border-collapse: collapse;
           font-size: 0.85rem;
           margin-bottom: 0;
 
           td {
-            padding: 0.55rem 0.75rem 0.55rem 0;
+            border: 1px solid #dee2e6;
+            padding: 0.55rem 0.75rem;
+            vertical-align: middle;
           }
         }
 
-        .release-data-links-table-container {
+        .release-data-links-table-container,
+        .additional-download-table-container {
           h6 {
+            color: #343a40;
+            font-weight: 600;
             margin-top: 1.25rem;
           }
         }


### PR DESCRIPTION
### Key Changes:

1. On the data hub release page, added UIs for the new internal data release.
2. On the landing page, updated the announcement UI for the 1st MoTrPAC Marker paper published in _Cell_.
3. On the announcement page, added a new announcement item for the 1st MoTrPAC Marker paper published in _Cell_.

### Technical Notes:

Because the data structure in this new release is no longer consistent with prior releases, I opted to create variants of a single component that was responsible to render the downloadable release data table regardless internal/external releases. Going forward, these variants will each be responsible to render the release data table given the release type/version.