### PR TITLE
MOTR-263 Final release 2 RC fix

### DIFF
--- a/src/ReleasePage/releases.json
+++ b/src/ReleasePage/releases.json
@@ -161,7 +161,7 @@
             "tooltip_id": "data-pass1b-06-phenotype-int-2-0",
             "object_path": "/pass1b-06/phenotype",
             "object_zipfile": "motrpac_pass1b-06_phenotype.tar.gz",
-            "object_zipfile_size": "5.89 MB"
+            "object_zipfile_size": "5.80 MB"
           },
           {
             "type": "all",


### PR DESCRIPTION
### Key Changes:

1. Updated pass1b-06 phenotype zip file size on **Release Page**.