### PR TITLE
Connects to #89. Adding QC sample counts to dashboard visualization.

### DIFF
--- a/src/Dashboard/__test__/dashboard.test.jsx
+++ b/src/Dashboard/__test__/dashboard.test.jsx
@@ -20,6 +20,7 @@ const controlActions = {
   togglePhase: jest.fn(),
   togglePlot: jest.fn(),
   toggleSort: jest.fn(),
+  toggleQC: jest.fn(),
 };
 
 describe('Shallow Dashboard', () => {

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -15,9 +15,18 @@ const animalReleaseSamples = require('../data/animal_release_samples');
 /**
  * Renders the Dashboard page.
  *
- * @param {Array}     previousUploads Redux state for user's historic uploads.
- * @param {Boolean}   isPending       Redux state for authentication status.
- * @param {Function}  clearForm       Redux upload action.
+ * @param {Object} profile          Redux state of authenticated user profile
+ * @param {Boolean} expanded        Redux state of collapsed/expanded sidebar
+ * @param {String} release          Redux state of user-selected release
+ * @param {String} phase            Redux state of user-selected phase
+ * @param {String} plot             Redux state of plot selection
+ * @param {String} sort             Redux state of table sort
+ * @param {Boolean} showQC          Redux state of QC sample visibility
+ * @param {Function} toggleRelease  Redux action to change release state
+ * @param {Function} togglePhase    Redux action to change phase state
+ * @param {Function} togglePlot     Redux action to change plot state
+ * @param {Function} toggleSort     Redux action to change sort state
+ * @param {Function} toggleQC       Redux action to change visibility state
  *
  * @returns {object} JSX representation of the global footer.
  */
@@ -37,6 +46,8 @@ export function Dashboard({
 }) {
   const userType = profile.user_metadata && profile.user_metadata.userType;
 
+  // Returns a subset of the release sample data based on a number of factors:
+  // internal or external, user's selection of release/phase
   const sampleData = () => {
     let data =
       userType === 'external'

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -28,10 +28,12 @@ export function Dashboard({
   phase,
   plot,
   sort,
+  showQC,
   toggleRelease,
   togglePhase,
   togglePlot,
   toggleSort,
+  toggleQC,
 }) {
   const userType = profile.user_metadata && profile.user_metadata.userType;
 
@@ -149,8 +151,17 @@ export function Dashboard({
                 <ReleasedSamplePlot data={sampleData()} plot={plot} />
               </div>
               <div className="release-sample-table">
-                <TableControls toggleSort={toggleSort} sort={sort} />
-                <ReleasedSampleTable data={sampleData()} sort={sort} />
+                <TableControls
+                  toggleSort={toggleSort}
+                  sort={sort}
+                  toggleQC={toggleQC}
+                  showQC={showQC}
+                />
+                <ReleasedSampleTable
+                  data={sampleData()}
+                  sort={sort}
+                  showQC={showQC}
+                />
               </div>
             </div>
           </div>
@@ -183,10 +194,12 @@ Dashboard.propTypes = {
   phase: PropTypes.string,
   plot: PropTypes.string,
   sort: PropTypes.string,
+  showQC: PropTypes.bool,
   toggleRelease: PropTypes.func.isRequired,
   togglePhase: PropTypes.func.isRequired,
   togglePlot: PropTypes.func.isRequired,
   toggleSort: PropTypes.func.isRequired,
+  toggleQC: PropTypes.func.isRequired,
 };
 
 Dashboard.defaultProps = {
@@ -196,6 +209,7 @@ Dashboard.defaultProps = {
   phase: 'pass1a_06',
   plot: 'tissue_name',
   sort: 'default',
+  showQC: true,
 };
 
 const mapStateToProps = (state) => ({
@@ -209,6 +223,7 @@ const mapDispatchToProps = (dispatch) => ({
   togglePhase: (phase) => dispatch(dashboardActions.togglePhase(phase)),
   togglePlot: (plot) => dispatch(dashboardActions.togglePlot(plot)),
   toggleSort: (sort) => dispatch(dashboardActions.toggleSort(sort)),
+  toggleQC: (visible) => dispatch(dashboardActions.toggleQC(visible)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Dashboard);

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -179,9 +179,6 @@ export function Dashboard({
         </div>
         <div className="d-flex col-lg-3">
           <div className="flex-fill w-100 card shadow-sm">
-            <h5 className="card-header">
-              <div className="card-title mb-0">Total Assays</div>
-            </h5>
             <div className="card-body">
               <ReleasedSampleSummary
                 data={animalReleaseSamples}

--- a/src/Dashboard/dashboardActions.js
+++ b/src/Dashboard/dashboardActions.js
@@ -2,6 +2,7 @@ export const TOGGLE_RELEASE = 'TOGGLE_RELEASE';
 export const TOGGLE_PHASE = 'TOGGLE_PHASE';
 export const TOGGLE_PLOT = 'TOGGLE_PLOT';
 export const TOGGLE_SORT = 'TOGGLE_SORT';
+export const TOGGLE_QC = 'TOGGLE_QC';
 
 function toggleRelease(release) {
   return {
@@ -31,11 +32,19 @@ function toggleSort(sort) {
   };
 }
 
+function toggleQC(visible) {
+  return {
+    type: TOGGLE_QC,
+    visible,
+  };
+}
+
 const DashboardActions = {
   toggleRelease,
   togglePhase,
   togglePlot,
   toggleSort,
+  toggleQC,
 };
 
 export default DashboardActions;

--- a/src/Dashboard/dashboardReducer.js
+++ b/src/Dashboard/dashboardReducer.js
@@ -3,6 +3,7 @@ import {
   TOGGLE_PHASE,
   TOGGLE_PLOT,
   TOGGLE_SORT,
+  TOGGLE_QC,
 } from './dashboardActions';
 
 export const defaultDashboardState = {
@@ -10,6 +11,7 @@ export const defaultDashboardState = {
   phase: 'pass1a_06',
   plot: 'tissue_name',
   sort: 'default',
+  showQC: false,
 };
 
 export function DashboardReducer(state = { ...defaultDashboardState }, action) {
@@ -36,6 +38,12 @@ export function DashboardReducer(state = { ...defaultDashboardState }, action) {
       return {
         ...state,
         sort: action.sort,
+      };
+
+    case TOGGLE_QC:
+      return {
+        ...state,
+        showQC: action.visible,
       };
 
     default:

--- a/src/Widgets/plotControls.jsx
+++ b/src/Widgets/plotControls.jsx
@@ -33,7 +33,10 @@ function PlotControls({ plot, togglePlot }) {
             >
               {plotViewLabels[plot]}
             </button>
-            <div className="dropdown-menu" aria-labelledby="plotViewMenu">
+            <div
+              className="dropdown-menu animate slideIn"
+              aria-labelledby="plotViewMenu"
+            >
               <button
                 className="dropdown-item"
                 type="button"

--- a/src/Widgets/releasedSampleHighlight.jsx
+++ b/src/Widgets/releasedSampleHighlight.jsx
@@ -17,15 +17,21 @@ function ReleasedSampleHighlight({ data }) {
   // Utility function to get total count of
   // a given omic from each tissue
   function omicSet(omic) {
-    let count = 0;
+    let studyCount = 0;
+    let qcCount = 0;
+    let totalCount = 0;
     data.forEach((tissueSample) => {
       tissueSample.sample_data.forEach((item) => {
         if (item.omics_code === omic && item.count) {
-          count += Number(item.count);
+          studyCount += Number(item.count);
+          if (item.qc_count) {
+            qcCount += Number(item.qc_count);
+          }
+          totalCount = studyCount + qcCount;
         }
       });
     });
-    return count;
+    return totalCount;
   }
 
   // Get count for a given metric

--- a/src/Widgets/releasedSamplePlot.jsx
+++ b/src/Widgets/releasedSamplePlot.jsx
@@ -115,7 +115,7 @@ function ReleasedSamplePlot({ data, plot }) {
     ),
     datasets: [
       {
-        label: 'Total Sample Count',
+        label: 'Total Assay Count',
         data: sortedDataset(plot).map((item) => item.sample_count),
         borderWidth: 1,
         backgroundColor: colors.graphs.lblue,

--- a/src/Widgets/releasedSampleSummary.jsx
+++ b/src/Widgets/releasedSampleSummary.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Pie } from 'react-chartjs-2';
+import { Pie, Doughnut } from 'react-chartjs-2';
 
 /**
  * Renders chart.js plots of release sample summary on dashboard
@@ -398,10 +398,10 @@ function ReleasedSampleSummary({ data, release, userType }) {
         Total Reference Standards
       </h5>
       <div>
-        <Pie data={omicsDataQC} options={options} height={350} />
+        <Doughnut data={omicsDataQC} options={options} height={350} />
       </div>
       <div className="mt-3">
-        <Pie data={phaseDataQC} options={options} height={315} />
+        <Doughnut data={phaseDataQC} options={options} height={315} />
       </div>
     </div>
   );

--- a/src/Widgets/releasedSampleSummary.jsx
+++ b/src/Widgets/releasedSampleSummary.jsx
@@ -6,23 +6,33 @@ import { Pie } from 'react-chartjs-2';
  * Renders chart.js plots of release sample summary on dashboard
  *
  * @param {Array} data      Metadata of release samples
- * @param {String} release  Array of tissue sample metadata by phase/release
+ * @param {String} release  User-selected release state
+ * @param {String} userType User who is either internal or external
  *
  * @returns {object} JSX representation of the dashboard sample count plots
  */
 function ReleasedSampleSummary({ data, release, userType }) {
   // Utility function to get total count of
   // a given omic from each tissue
-  function countSamples(tissueList, omic) {
-    let count = 0;
+  function countSamples(tissueList, omic, countType) {
+    let studyCount = 0;
+    let qcCount = 0;
     tissueList.forEach((tissue) => {
       tissue.sample_data.forEach((item) => {
         if (item.omics_code === omic && item.count) {
-          count += Number(item.count);
+          studyCount += Number(item.count);
+          if (item.qc_count) {
+            qcCount += Number(item.qc_count);
+          }
         }
       });
     });
-    return count;
+
+    if (countType && countType === 'qcCount') {
+      return qcCount;
+    }
+
+    return studyCount;
   }
 
   // Get count for a given metric
@@ -30,35 +40,42 @@ function ReleasedSampleSummary({ data, release, userType }) {
     const countObject = {
       transcriptomics: {
         label: 'Transcriptomics',
-        count: 0,
+        studyCount: 0,
+        qcCount: 0,
       },
       epigenomics: {
         label: 'Epigenomics',
-        count: 0,
+        studyCount: 0,
+        qcCount: 0,
       },
       metabolomics_targeted: {
         label: 'Metabolomics Targeted',
-        count: 0,
+        studyCount: 0,
+        qcCount: 0,
       },
       metabolomics_untargeted: {
         label: 'Metabolomics Untargeted',
-        count: 0,
+        studyCount: 0,
+        qcCount: 0,
       },
       proteomics: {
         label: 'Proteomics',
-        count: 0,
+        studyCount: 0,
+        qcCount: 0,
       },
       pass1a_06: {
         label: 'PASS1A 6-Month',
-        count: 0,
+        studyCount: 0,
+        qcCount: 0,
       },
       pass1b_06: {
         label: 'PASS1B 6-Month',
-        count: 0,
+        studyCount: 0,
+        qcCount: 0,
       },
     };
     if (metric === 'internal') {
-      // internal pass1a_06 samples
+      // internal pass1a_06 'study' samples for each omic
       const internalPass1A06TranscriptCount = countSamples(
         data.internal.pass1a_06,
         'transcriptomics'
@@ -79,7 +96,33 @@ function ReleasedSampleSummary({ data, release, userType }) {
         data.internal.pass1a_06,
         'proteomics'
       );
-      // internal pass1b_06 samples
+      // internal pass1a_06 'QC' samples for each omic
+      const internalPass1A06TranscriptCountQC = countSamples(
+        data.internal.pass1a_06,
+        'transcriptomics',
+        'qcCount'
+      );
+      const internalPass1A06EpigenCountQC = countSamples(
+        data.internal.pass1a_06,
+        'epigenomics',
+        'qcCount'
+      );
+      const internalPass1A06MetaTargCountQC = countSamples(
+        data.internal.pass1a_06,
+        'metabolomics-targeted',
+        'qcCount'
+      );
+      const internalPass1A06MetaUntargCountQC = countSamples(
+        data.internal.pass1a_06,
+        'metabolomics-untargeted',
+        'qcCount'
+      );
+      const internalPass1A06ProtCountQC = countSamples(
+        data.internal.pass1a_06,
+        'proteomics',
+        'qcCount'
+      );
+      // internal pass1b_06 'study' samples for each omic
       const internalPass1B06TranscriptCount = countSamples(
         data.internal.pass1b_06,
         'transcriptomics'
@@ -100,31 +143,80 @@ function ReleasedSampleSummary({ data, release, userType }) {
         data.internal.pass1b_06,
         'proteomics'
       );
-      // assign internal release sample counts
-      countObject.transcriptomics.count =
+      // internal pass1b_06 'QC' samples for each omic
+      const internalPass1B06TranscriptCountQC = countSamples(
+        data.internal.pass1b_06,
+        'transcriptomics',
+        'qcCount'
+      );
+      const internalPass1B06EpigenCountQC = countSamples(
+        data.internal.pass1b_06,
+        'epigenomics',
+        'qcCount'
+      );
+      const internalPass1B06MetaTargCountQC = countSamples(
+        data.internal.pass1b_06,
+        'metabolomics-targeted',
+        'qcCount'
+      );
+      const internalPass1B06MetaUntargCountQC = countSamples(
+        data.internal.pass1b_06,
+        'metabolomics-untargeted',
+        'qcCount'
+      );
+      const internalPass1B06ProtCountQC = countSamples(
+        data.internal.pass1b_06,
+        'proteomics',
+        'qcCount'
+      );
+      // assign internal release 'study' sample counts
+      countObject.transcriptomics.studyCount =
         internalPass1A06TranscriptCount + internalPass1B06TranscriptCount;
-      countObject.epigenomics.count =
+      countObject.epigenomics.studyCount =
         internalPass1A06EpigenCount + internalPass1B06EpigenCount;
-      countObject.metabolomics_targeted.count =
+      countObject.metabolomics_targeted.studyCount =
         internalPass1A06MetaTargCount + internalPass1B06MetaTargCount;
-      countObject.metabolomics_untargeted.count =
+      countObject.metabolomics_untargeted.studyCount =
         internalPass1A06MetaUntargCount + internalPass1B06MetaUntargCount;
-      countObject.proteomics.count =
+      countObject.proteomics.studyCount =
         internalPass1A06ProtCount + internalPass1B06ProtCount;
-      countObject.pass1a_06.count =
+      countObject.pass1a_06.studyCount =
         internalPass1A06TranscriptCount +
         internalPass1A06EpigenCount +
         internalPass1A06MetaTargCount +
         internalPass1A06MetaUntargCount +
         internalPass1A06ProtCount;
-      countObject.pass1b_06.count =
+      countObject.pass1b_06.studyCount =
         internalPass1B06TranscriptCount +
         internalPass1B06EpigenCount +
         internalPass1B06MetaTargCount +
         internalPass1B06MetaUntargCount +
         internalPass1B06ProtCount;
+      // assign internal release 'QC' sample counts
+      countObject.transcriptomics.qcCount =
+        internalPass1A06TranscriptCountQC + internalPass1B06TranscriptCountQC;
+      countObject.epigenomics.qcCount =
+        internalPass1A06EpigenCountQC + internalPass1B06EpigenCountQC;
+      countObject.metabolomics_targeted.qcCount =
+        internalPass1A06MetaTargCountQC + internalPass1B06MetaTargCountQC;
+      countObject.metabolomics_untargeted.qcCount =
+        internalPass1A06MetaUntargCountQC + internalPass1B06MetaUntargCountQC;
+      countObject.proteomics.qcCount =
+        internalPass1A06ProtCountQC + internalPass1B06ProtCountQC;
+      countObject.pass1a_06.qcCount =
+        internalPass1A06TranscriptCountQC +
+        internalPass1A06EpigenCountQC +
+        internalPass1A06MetaTargCountQC +
+        internalPass1A06MetaUntargCountQC +
+        internalPass1A06ProtCountQC;
+      countObject.pass1b_06.qcCount =
+        internalPass1B06TranscriptCountQC +
+        internalPass1B06EpigenCountQC +
+        internalPass1B06MetaTargCountQC +
+        internalPass1B06MetaUntargCountQC +
+        internalPass1B06ProtCountQC;
     } else if (metric === 'external') {
-      // external pass1a_06 samples
+      // external pass1a_06 'study' samples for each omic
       const externalPass1A06TranscriptCount = countSamples(
         data.external.pass1a_06,
         'transcriptomics'
@@ -145,18 +237,56 @@ function ReleasedSampleSummary({ data, release, userType }) {
         data.external.pass1a_06,
         'proteomics'
       );
+      // external pass1a_06 'QC' samples for each omic
+      const externalPass1A06TranscriptCountQC = countSamples(
+        data.external.pass1a_06,
+        'transcriptomics',
+        'qcCount'
+      );
+      const externalPass1A06EpigenCountQC = countSamples(
+        data.external.pass1a_06,
+        'epigenomics',
+        'qcCount'
+      );
+      const externalPass1A06MetaTargCountQC = countSamples(
+        data.external.pass1a_06,
+        'metabolomics-targeted',
+        'qcCount'
+      );
+      const externalPass1A06MetaUntargCountQC = countSamples(
+        data.external.pass1a_06,
+        'metabolomics-untargeted',
+        'qcCount'
+      );
+      const externalPass1A06ProtCountQC = countSamples(
+        data.external.pass1a_06,
+        'proteomics',
+        'qcCount'
+      );
       // assign external release sample counts
-      countObject.transcriptomics.count = externalPass1A06TranscriptCount;
-      countObject.epigenomics.count = externalPass1A06EpigenCount;
-      countObject.metabolomics_targeted.count = externalPass1A06MetaTargCount;
-      countObject.metabolomics_untargeted.count = externalPass1A06MetaUntargCount;
-      countObject.proteomics.count = externalPass1A06ProtCount;
-      countObject.pass1a_06.count =
+      countObject.transcriptomics.studyCount = externalPass1A06TranscriptCount;
+      countObject.epigenomics.studyCount = externalPass1A06EpigenCount;
+      countObject.metabolomics_targeted.studyCount = externalPass1A06MetaTargCount;
+      countObject.metabolomics_untargeted.studyCount = externalPass1A06MetaUntargCount;
+      countObject.proteomics.studyCount = externalPass1A06ProtCount;
+      countObject.pass1a_06.studyCount =
         externalPass1A06TranscriptCount +
         externalPass1A06EpigenCount +
         externalPass1A06MetaTargCount +
         externalPass1A06MetaUntargCount +
         externalPass1A06ProtCount;
+      // assign external release sample counts
+      countObject.transcriptomics.qcCount = externalPass1A06TranscriptCountQC;
+      countObject.epigenomics.qcCount = externalPass1A06EpigenCountQC;
+      countObject.metabolomics_targeted.qcCount = externalPass1A06MetaTargCountQC;
+      countObject.metabolomics_untargeted.qcCount = externalPass1A06MetaUntargCountQC;
+      countObject.proteomics.qcCount = externalPass1A06ProtCountQC;
+      countObject.pass1a_06.qcCount =
+        externalPass1A06TranscriptCountQC +
+        externalPass1A06EpigenCountQC +
+        externalPass1A06MetaTargCountQC +
+        externalPass1A06MetaUntargCountQC +
+        externalPass1A06ProtCountQC;
     }
     return countObject;
   }
@@ -174,11 +304,39 @@ function ReleasedSampleSummary({ data, release, userType }) {
     datasets: [
       {
         data: [
-          summary.transcriptomics.count,
-          summary.epigenomics.count,
-          summary.metabolomics_targeted.count,
-          summary.metabolomics_untargeted.count,
-          summary.proteomics.count,
+          summary.transcriptomics.studyCount,
+          summary.epigenomics.studyCount,
+          summary.metabolomics_targeted.studyCount,
+          summary.metabolomics_untargeted.studyCount,
+          summary.proteomics.studyCount,
+        ],
+        backgroundColor: [
+          '#71BAF0',
+          '#ffde72',
+          '#93D689',
+          '#fd6666',
+          '#b566ff',
+        ],
+      },
+    ],
+  };
+
+  const omicsDataQC = {
+    labels: [
+      summary.transcriptomics.label,
+      summary.epigenomics.label,
+      summary.metabolomics_targeted.label,
+      summary.metabolomics_untargeted.label,
+      summary.proteomics.label,
+    ],
+    datasets: [
+      {
+        data: [
+          summary.transcriptomics.qcCount,
+          summary.epigenomics.qcCount,
+          summary.metabolomics_targeted.qcCount,
+          summary.metabolomics_untargeted.qcCount,
+          summary.proteomics.qcCount,
         ],
         backgroundColor: [
           '#71BAF0',
@@ -195,7 +353,17 @@ function ReleasedSampleSummary({ data, release, userType }) {
     labels: [summary.pass1a_06.label, summary.pass1b_06.label],
     datasets: [
       {
-        data: [summary.pass1a_06.count, summary.pass1b_06.count],
+        data: [summary.pass1a_06.studyCount, summary.pass1b_06.studyCount],
+        backgroundColor: ['#56bf46', '#f9c002'],
+      },
+    ],
+  };
+
+  const phaseDataQC = {
+    labels: [summary.pass1a_06.label, summary.pass1b_06.label],
+    datasets: [
+      {
+        data: [summary.pass1a_06.qcCount, summary.pass1b_06.qcCount],
         backgroundColor: ['#56bf46', '#f9c002'],
       },
     ],
@@ -217,11 +385,23 @@ function ReleasedSampleSummary({ data, release, userType }) {
 
   return (
     <div className="release-sample-summary-plots">
+      <h5 className="release-sample-summary-plots-title mb-4">
+        Total Study Assays
+      </h5>
       <div>
         <Pie data={omicsData} options={options} height={350} />
       </div>
-      <div className="mt-4">
+      <div className="mt-3">
         <Pie data={phaseData} options={options} height={315} />
+      </div>
+      <h5 className="release-sample-summary-plots-title mt-5 mb-4">
+        Total Reference Standards
+      </h5>
+      <div>
+        <Pie data={omicsDataQC} options={options} height={350} />
+      </div>
+      <div className="mt-3">
+        <Pie data={phaseDataQC} options={options} height={315} />
       </div>
     </div>
   );

--- a/src/Widgets/releasedSampleTable.jsx
+++ b/src/Widgets/releasedSampleTable.jsx
@@ -10,7 +10,7 @@ import tissues from '../lib/tissueCodes';
  *
  * @returns {object} JSX representation of the dashboard sample count table
  */
-function ReleasedSampleTable({ data, sort }) {
+function ReleasedSampleTable({ data, sort, showQC }) {
   // Create new set of sorted data
   function datasetWithTissueName() {
     const clonedData = [...data];
@@ -83,8 +83,9 @@ function ReleasedSampleTable({ data, sort }) {
             </td>
             {tissue.sample_data.map((row) => {
               return (
-                <td key={`${row.assay_code}${row.count}`}>
-                  {row.count ? row.count : ' '}
+                <td key={`${tissue.tissue_code}_${row.assay_code}`}>
+                  {!showQC && row.count ? row.count : ' '}
+                  {showQC && row.qc_count ? row.qc_count : ' '}
                 </td>
               );
             })}
@@ -114,6 +115,7 @@ ReleasedSampleTable.propTypes = {
     })
   ).isRequired,
   sort: PropTypes.string.isRequired,
+  showQC: PropTypes.bool.isRequired,
 };
 
 export default ReleasedSampleTable;

--- a/src/Widgets/tableControls.jsx
+++ b/src/Widgets/tableControls.jsx
@@ -12,13 +12,15 @@ const tableSortLabels = {
  *
  * @param {String} sort           Redux state of table sort
  * @param {Function} toggleSort   Redux action to change sort state
+ * @param {Boolean} showQC        Redux state of QC sample visibility
+ * @param {Function} toggleQC     Redux action to change visibility state
  *
  * @returns {object} JSX representation of the dropdown menu controls
  */
-function TableControls({ sort, toggleSort }) {
+function TableControls({ sort, toggleSort, showQC, toggleQC }) {
   return (
     <div className="controlPanelContainer mb-3 mx-3">
-      <div className="controlPanel">
+      <div className="controlPanel d-flex align-items-center">
         <div className="controlRow d-flex align-items-center">
           <div className="controlLabel">Sort:</div>
           <div className="dropdown">
@@ -32,7 +34,10 @@ function TableControls({ sort, toggleSort }) {
             >
               {tableSortLabels[sort]}
             </button>
-            <div className="dropdown-menu" aria-labelledby="tableSortMenu">
+            <div
+              className="dropdown-menu animate slideIn"
+              aria-labelledby="tableSortMenu"
+            >
               <button
                 className="dropdown-item"
                 type="button"
@@ -57,6 +62,20 @@ function TableControls({ sort, toggleSort }) {
             </div>
           </div>
         </div>
+        <div className="controlRow show-qc-sample-table ml-3">
+          <button
+            className="btn btn-sm shadow-none"
+            type="button"
+            onClick={toggleQC.bind(this, !showQC)}
+          >
+            <span className="d-flex align-items-center justify-content-start">
+              <i className="material-icons show-qc-icon mr-1">
+                {showQC ? 'check_box' : 'check_box_outline_blank'}
+              </i>
+              Reference Standards
+            </span>
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -65,10 +84,13 @@ function TableControls({ sort, toggleSort }) {
 TableControls.propTypes = {
   sort: PropTypes.string,
   toggleSort: PropTypes.func.isRequired,
+  showQC: PropTypes.bool,
+  toggleQC: PropTypes.func.isRequired,
 };
 
 TableControls.defaultProps = {
   sort: 'default',
+  showQC: false,
 };
 
 export default TableControls;

--- a/src/data/animal_release_samples.json
+++ b/src/data/animal_release_samples.json
@@ -8,151 +8,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -163,151 +188,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 6
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 6
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 6
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 27
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 6
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 23
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 77
+            "count": 77,
+            "qc_count": 20
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 20
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 77
+            "count": 77,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 77
+            "count": 77,
+            "qc_count": 24
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -318,151 +368,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": 105
+            "count": 105,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": 105
+            "count": 105,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": 105
+            "count": 105,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 59
+            "count": 59,
+            "qc_count": 28
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": 99
+            "count": 99,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 20
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 73
+            "count": 73,
+            "qc_count": 21
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 73
+            "count": 73,
+            "qc_count": 24
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 35
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 39
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -473,151 +548,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -628,151 +728,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 56
+            "count": 56,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -783,151 +908,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 156
+            "count": 156,
+            "qc_count": 8
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": 234
+            "count": 234,
+            "qc_count": 12
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 12
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": 234
+            "count": 234,
+            "qc_count": 12
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 27
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 11
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 23
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 26
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 20
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 21
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           }
         ]
       },
@@ -938,151 +1088,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 77
+            "count": 77,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -1093,151 +1268,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 16
+            "count": 16,
+            "qc_count": 12
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -1248,151 +1448,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 4
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": 154
+            "count": 154,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": 154
+            "count": 154,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": 154
+            "count": 154,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 77
+            "count": 77,
+            "qc_count": 30
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": 154
+            "count": 154,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 42
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 21
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 22
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 42
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 42
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           }
         ]
       },
@@ -1403,151 +1628,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 8
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 27
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 77
+            "count": 77,
+            "qc_count": 41
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 21
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 21
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 42
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 42
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -1558,151 +1808,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -1713,151 +1988,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -1868,151 +2168,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -2023,151 +2348,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 39
+            "count": 39,
+            "qc_count": 14
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -2178,151 +2528,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 39
+            "count": 39,
+            "qc_count": 6
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -2333,151 +2708,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 77
+            "count": 77,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -2488,151 +2888,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 4
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 29
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 42
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 21
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 29
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 42
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 42
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -2643,151 +3068,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -2798,151 +3248,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": 234
+            "count": 234,
+            "qc_count": 24
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 12
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": 234
+            "count": 234,
+            "qc_count": 8
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 27
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 8
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 23
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 30
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 20
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 25
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 34
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           }
         ]
       },
@@ -2953,151 +3428,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": 137
+            "count": 137,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": 137
+            "count": 137,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": 137
+            "count": 137,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 29
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": 137
+            "count": 137,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 38
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 21
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 21
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 38
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 39
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -3108,151 +3608,176 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-atac-seq",
             "assay_name": "ATAC-seq",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": 234
+            "count": 234,
+            "qc_count": 24
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 11
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": 234
+            "count": 234,
+            "qc_count": 24
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 27
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 8
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 23
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 61
+            "count": 61,
+            "qc_count": 26
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 76
+            "count": 76,
+            "qc_count": 36
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 74
+            "count": 74,
+            "qc_count": 35
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           }
         ]
       }
@@ -3265,67 +3790,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -3336,67 +3872,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 29
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 39
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 30
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 28
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -3407,67 +3954,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 6
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 49
+            "count": 49,
+            "qc_count": 24
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 49
+            "count": 49,
+            "qc_count": 40
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 49
+            "count": 49,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 49
+            "count": 49,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 49
+            "count": 49,
+            "qc_count": 40
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 49
+            "count": 49,
+            "qc_count": 40
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -3478,67 +4036,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -3549,67 +4118,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 46
+            "count": 46,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -3620,67 +4200,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 10
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 29
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 38
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 39
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 40
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           }
         ]
       },
@@ -3691,67 +4282,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -3762,67 +4364,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -3833,67 +4446,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 40
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 40
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 40
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 36
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           }
         ]
       },
@@ -3904,67 +4528,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 27
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 40
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 41
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 42
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -3975,67 +4610,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -4046,67 +4692,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -4117,67 +4774,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -4188,67 +4856,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 25
+            "count": 25,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 25
+            "count": 25,
+            "qc_count": 14
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -4259,67 +4938,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 24
+            "count": 24,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 25
+            "count": 25,
+            "qc_count": 6
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -4330,67 +5020,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 42
+            "count": 42,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -4401,67 +5102,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 29
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 41
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 41
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 40
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -4472,67 +5184,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -4543,67 +5266,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 4
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 29
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 41
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 41
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 41
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           }
         ]
       },
@@ -4614,67 +5348,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 33
+            "count": 33,
+            "qc_count": 27
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 49
+            "count": 49,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 46
+            "count": 46,
+            "qc_count": 36
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 39
+            "count": 39,
+            "qc_count": 17
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 39
+            "count": 39,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 46
+            "count": 46,
+            "qc_count": 40
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 46
+            "count": 46,
+            "qc_count": 40
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -4685,67 +5430,78 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 50
+            "count": 50,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 29
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 16
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 40
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 33
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 50
+            "count": 50,
+            "qc_count": 40
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           }
         ]
       }
@@ -4760,145 +5516,169 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -4909,145 +5689,169 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 6
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 6
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 6
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 26
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 6
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 23
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 33
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 20
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 27
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 26
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           }
         ]
       },
@@ -5058,145 +5862,169 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 156
+            "count": 156,
+            "qc_count": 6
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": 234
+            "count": 234,
+            "qc_count": 12
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 12
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": 234
+            "count": 234,
+            "qc_count": 12
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 27
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 11
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 23
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 38
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 19
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 23
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 32
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           }
         ]
       },
@@ -5207,145 +6035,169 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           }
         ]
       },
@@ -5356,145 +6208,169 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": 234
+            "count": 234,
+            "qc_count": 24
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 12
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": 234
+            "count": 234,
+            "qc_count": 8
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 27
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 8
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 23
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 39
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 33
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 34
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           }
         ]
       },
@@ -5505,145 +6381,169 @@
             "assay_code": "transcript-rna-seq",
             "assay_name": "RNA-seq",
             "omics_code": "transcriptomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "epigen-rrbs",
             "assay_name": "RRBS",
             "omics_code": "epigenomics",
-            "count": 78
+            "count": 78,
+            "qc_count": 2
           },
           {
             "assay_code": "metab-t-3hib",
             "assay_name": "Targeted 3-Hydroxyisobutyric Acid (3-HIB)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-aa",
             "assay_name": "Targeted Amino Acids",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-ac-duke",
             "assay_name": "Targeted Acylcarnitines",
             "omics_code": "metabolomics-targeted",
-            "count": 234
+            "count": 234,
+            "qc_count": 24
           },
           {
             "assay_code": "metab-t-acoa",
             "assay_name": "Targeted Acyl-CoA",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-amines",
             "assay_name": "Targeted Amines",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 11
           },
           {
             "assay_code": "metab-t-baiba",
             "assay_name": "Targeted Beta-aminoisobutyric acid (BAIBA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-cer-duke",
             "assay_name": "Targeted Ceramide",
             "omics_code": "metabolomics-targeted",
-            "count": 234
+            "count": 234,
+            "qc_count": 24
           },
           {
             "assay_code": "metab-t-ka",
             "assay_name": "Targeted Keto acids (KA)",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-nuc",
             "assay_name": "Targeted Nucleotides",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oa",
             "assay_name": "Targeted Organic acids (OA)",
             "omics_code": "metabolomics-targeted",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-oxylipneg",
             "assay_name": "Targeted Oxylipins",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 26
           },
           {
             "assay_code": "metab-t-sphm",
             "assay_name": "Targeted Sphingomyelin",
             "omics_code": "metabolomics-targeted",
-            "count": 78
+            "count": 78,
+            "qc_count": null
           },
           {
             "assay_code": "metab-t-tca",
             "assay_name": "Targeted Tricarboxylic acid (TCA) cycle",
             "omics_code": "metabolomics-targeted",
-            "count": 156
+            "count": 156,
+            "qc_count": 8
           },
           {
             "assay_code": "metab-u-hilicpos",
             "assay_name": "Untargeted HILIC-positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 23
           },
           {
             "assay_code": "metab-u-ionpneg",
             "assay_name": "Untargeted Ion-Pair negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 62
+            "count": 62,
+            "qc_count": 31
           },
           {
             "assay_code": "metab-u-lrpneg",
             "assay_name": "Untargeted lipidomics, reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-lrppos",
             "assay_name": "Untargeted lipidomics, reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 18
           },
           {
             "assay_code": "metab-u-rpneg",
             "assay_name": "Untargeted Reversed-phase negative",
             "omics_code": "metabolomics-untargeted",
-            "count": 78
+            "count": 78,
+            "qc_count": 37
           },
           {
             "assay_code": "metab-u-rppos",
             "assay_name": "Untargeted Reversed-phase positive",
             "omics_code": "metabolomics-untargeted",
-            "count": 76
+            "count": 76,
+            "qc_count": 36
           },
           {
             "assay_code": "prot-ac",
             "assay_name": "Acetyl Proteomics",
             "omics_code": "proteomics",
-            "count": null
+            "count": null,
+            "qc_count": null
           },
           {
             "assay_code": "prot-ph",
             "assay_name": "Phophoproteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           },
           {
             "assay_code": "prot-pr",
             "assay_name": "Global Proteomics",
             "omics_code": "proteomics",
-            "count": 66
+            "count": 66,
+            "qc_count": null
           }
         ]
       }

--- a/src/sass/dashboard/_dashboard.scss
+++ b/src/sass/dashboard/_dashboard.scss
@@ -127,6 +127,16 @@
         button.dropdown-item {
           font-size: 0.85rem;
         }
+
+        &.show-qc-sample-table {
+          button.btn {
+            color: $stanford-cool-grey;
+
+            &:hover {
+              color: $stanford-cool-grey;
+            }
+          }
+        }
       }
     }
   }
@@ -311,4 +321,50 @@
       padding-right: 0;
     }
   }
+}
+
+/* Animation settings for plot and table dropdown menus */
+
+@media (min-width: 992px) {
+  .controlPanel .animate {
+    animation-duration: 0.3s;
+    -webkit-animation-duration: 0.3s;
+    animation-fill-mode: both;
+    -webkit-animation-fill-mode: both;
+  }
+}
+
+@keyframes slideIn {
+  0% {
+    transform: translateY(2.45rem);
+    opacity: 0;
+  }
+  100% {
+    transform:translateY(1.85rem);
+    opacity: 1;
+  }
+  0% {
+    transform: translateY(2.45rem);
+    opacity: 0;
+  }
+}
+
+@-webkit-keyframes slideIn {
+  0% {
+    -webkit-transform: translateY(2.45rem);
+    -webkit-opacity: 0;
+  }
+  100% {
+    -webkit-transform: translateY(1.85rem);
+    -webkit-opacity: 1;
+  }
+  0% {
+    -webkit-transform: translateY(2.45rem);
+    -webkit-opacity: 0;
+  }
+}
+
+.controlPanel .slideIn {
+  -webkit-animation-name: slideIn;
+  animation-name: slideIn;
 }


### PR DESCRIPTION
### Key Changes

#### Note: QC sample counts are labeled as "Reference Standards" per Archana's suggestion

1. Adding QC sample counts to the highlighted totals (e.g. genomics, metabolomics, proteomics) at the top of dashboard page.
2. Adding QC sample counts to dashboard bar plot.
3. Adding option to show/hide QC sample counts in dashboard sample count table.
4. Added doughnut charts to visualize total QC sample counts.

#### Steps to test:
1. Sign into local instance of this branch and go to ^/dashboard.
2. Expect to see the totals of _genomic_ and _metabolomics_ assays are great than those currently seen in production.
3. Expect to see the bar plot showing stacked _study assays_ and _reference standards_.
4. Expect to see a _checkbox_ option to show/hide the _reference standards_ (QC samples counts) in the table.
5. Expect to see 2 new doughnut charts to the right of the page showing the total _reference standards_ for both internal and external releases.