### PR TITLE
Fixed typos in descriptions of animal phenotypic data plots

### DIFF
--- a/src/AnalysisPage/plots/bodyFatChange.jsx
+++ b/src/AnalysisPage/plots/bodyFatChange.jsx
@@ -113,7 +113,7 @@ function BodyFatChangePlot() {
         />
       </VictoryChart>
       <p className="card-text remark">
-        By matching each of the unique participant IDs from the <em>Animal Registratioin Form</em>, a dataset
+        By matching each of the unique participant IDs from the <em>Animal Registration Form</em>, a dataset
         is created by aggregating the entries from the <em>Animal NMR Testing Form</em>. The resulted
         dataset is further filtered to only retain those participants with two separate visits.
       </p>

--- a/src/AnalysisPage/plots/lactateChange.jsx
+++ b/src/AnalysisPage/plots/lactateChange.jsx
@@ -113,7 +113,7 @@ function LactateChangePlot() {
         />
       </VictoryChart>
       <p className="card-text remark">
-        By matching each of the unique participant IDs from the <em>Animal Registratioin Form</em>, a dataset
+        By matching each of the unique participant IDs from the <em>Animal Registration Form</em>, a dataset
         is created by aggregating the entries from the <em>Animal VO2 Max Test Form</em>. The resulted
         dataset is further filtered to only retain those participants with two separate visits.
       </p>

--- a/src/AnalysisPage/plots/vo2MaxChange.jsx
+++ b/src/AnalysisPage/plots/vo2MaxChange.jsx
@@ -113,7 +113,7 @@ function VO2MaxChangePlot() {
         />
       </VictoryChart>
       <p className="card-text remark">
-        By matching each of the unique participant IDs from the <em>Animal Registratioin Form</em>, a dataset
+        By matching each of the unique participant IDs from the <em>Animal Registration Form</em>, a dataset
         is created by aggregating the entries from the <em>Animal VO2 Max Test Form</em>. The resulted
         dataset is further filtered to only retain those participants with two separate visits.
       </p>

--- a/src/AnalysisPage/plots/weightGain.jsx
+++ b/src/AnalysisPage/plots/weightGain.jsx
@@ -123,7 +123,7 @@ function WeightGainPlot() {
       </VictoryChart>
       <p className="card-text remark">
         A dataset of pre-training weights is created given each of the unique
-        participant IDs from the <em>Animal Registratioin Form</em>. The dataset
+        participant IDs from the <em>Animal Registration Form</em>. The dataset
         of post-training weights is created by calculating the sum of pre-training
         weight and weight change after training for each of the participants.
       </p>


### PR DESCRIPTION
Fixed typos in descriptions for animal phenotype plots.

To test:
1. Clone this branch to local repo
2. Spin up local instance of portal with `yarn inspect-branch`
3. Navigate to 'Animal' on the left bar, then 'Phenotypic Data'
4. "Registration" should be correctly spelled