### PR TITLE
92 ct circular redirect updated

### DIFF
--- a/src/Auth/privateRoute.jsx
+++ b/src/Auth/privateRoute.jsx
@@ -3,18 +3,18 @@ import { Route, Redirect } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
 function PrivateRoute({ component, ...args }) {
-  const { isAuthenticated, profile } = useSelector((state) => state.auth);
 
+  const { isAuthenticated, isFetching, isPending, profile } = useSelector((state) => state.auth);
   const hasAccess = profile.user_metadata && profile.user_metadata.hasAccess;
 
   // Route users back to homepage if not authenticated
-  if (!isAuthenticated) {
+  if (!isPending && !isFetching && !isAuthenticated) {
     return <Redirect to="/" />;
   }
 
   // Route users to error page if registered users are
   // not allowed to have data access
-  if (isAuthenticated) {
+  if (!isPending && !isFetching && isAuthenticated) {
     if (!hasAccess) {
       return <Redirect to="/error" />;
     }

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import AuthContentContainer from '../lib/ui/authContentContainer';
@@ -43,7 +44,11 @@ export function Dashboard({
   togglePlot,
   toggleSort,
   toggleQC,
+  isAuthenticated,
+  isFetching,
+  isPending,
 }) {
+  const hasAccess = profile.user_metadata && profile.user_metadata.hasAccess;
   const userType = profile.user_metadata && profile.user_metadata.userType;
 
   // Returns a subset of the release sample data based on a number of factors:
@@ -67,130 +72,149 @@ export function Dashboard({
     return data;
   };
 
-  return (
-    <AuthContentContainer classes="Dashboard" expanded={expanded}>
-      <div className="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom page-header">
-        <div className="page-title">
-          <h3>Summary of Animal Study Assays</h3>
-        </div>
-        {userType === 'internal' && (
-          <div className="btn-toolbar">
-            <div className="btn-group">
-              <button
-                type="button"
-                className={`btn btn-sm btn-outline-primary ${
-                  release === 'internal' ? 'active' : ''
-                }`}
-                onClick={toggleRelease.bind(this, 'internal')}
-              >
-                Internal Release
-              </button>
-              <button
-                type="button"
-                className={`btn btn-sm btn-outline-primary ${
-                  release === 'external' ? 'active' : ''
-                }`}
-                onClick={toggleRelease.bind(this, 'external')}
-                disabled={phase === 'pass1b_06'}
-              >
-                External Release
-              </button>
-            </div>
-            <div className="btn-group ml-2">
-              <button
-                type="button"
-                className={`btn btn-sm btn-outline-primary ${
-                  phase === 'pass1a_06' ? 'active' : ''
-                }`}
-                onClick={togglePhase.bind(this, 'pass1a_06')}
-              >
-                PASS1A 6-Month
-              </button>
-              <button
-                type="button"
-                className={`btn btn-sm btn-outline-primary ${
-                  phase === 'pass1b_06' ? 'active' : ''
-                }`}
-                onClick={togglePhase.bind(this, 'pass1b_06')}
-                disabled={release === 'external'}
-              >
-                PASS1B 6-Month
-              </button>
-            </div>
-          </div>
-        )}
+  if (isPending) {
+    const pendingMsg = 'Authenticating...';
+
+    return (
+      <div className="authLoading">
+        <span className="oi oi-shield" />
+        <h3>{pendingMsg}</h3>
       </div>
-      <ReleasedSampleHighlight data={sampleData()} />
-      <div className="card-container-release-samples row mb-2">
-        <div className="d-flex col-lg-9">
-          <div className="flex-fill w-100 card shadow-sm">
-            <h5 className="card-header">
-              {userType === 'internal' && (
-                <div className="internal-user-labels float-right">
-                  {release === 'internal' && (
-                    <span className="badge badge-success ml-3">
-                      Internal Release
-                    </span>
-                  )}
-                  {release === 'external' && (
-                    <span className="badge badge-warning ml-3">
-                      External Release
-                    </span>
-                  )}
-                  {phase === 'pass1a_06' && (
-                    <span className="badge badge-secondary ml-2">
-                      PASS1A 6-Month
-                    </span>
-                  )}
-                  {phase === 'pass1b_06' && (
-                    <span className="badge badge-secondary ml-2">
-                      PASS1B 6-Month
-                    </span>
-                  )}
-                </div>
-              )}
-              {userType === 'external' && (
-                <div className="external-user-labels float-right">
-                  <span className="badge badge-secondary">PASS1A 6-Month</span>
-                </div>
-              )}
-              <div className="card-title mb-0">Overview</div>
-            </h5>
-            <div className="card-body pt-1">
-              <div className="release-sample-plot border-bottom pb-4 mb-4">
-                <PlotControls togglePlot={togglePlot} plot={plot} />
-                <ReleasedSamplePlot data={sampleData()} plot={plot} />
+    );
+  }
+
+  if (isAuthenticated) {
+    if (!hasAccess) {
+      return <Redirect to="/error/" />;
+    }
+
+    return (
+      <AuthContentContainer classes="Dashboard" expanded={expanded}>
+        <div className="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom page-header">
+          <div className="page-title">
+            <h3>Summary of Animal Study Assays</h3>
+          </div>
+          {userType === 'internal' && (
+            <div className="btn-toolbar">
+              <div className="btn-group">
+                <button
+                  type="button"
+                  className={`btn btn-sm btn-outline-primary ${
+                    release === 'internal' ? 'active' : ''
+                  }`}
+                  onClick={toggleRelease.bind(this, 'internal')}
+                >
+                  Internal Release
+                </button>
+                <button
+                  type="button"
+                  className={`btn btn-sm btn-outline-primary ${
+                    release === 'external' ? 'active' : ''
+                  }`}
+                  onClick={toggleRelease.bind(this, 'external')}
+                  disabled={phase === 'pass1b_06'}
+                >
+                  External Release
+                </button>
               </div>
-              <div className="release-sample-table">
-                <TableControls
-                  toggleSort={toggleSort}
-                  sort={sort}
-                  toggleQC={toggleQC}
-                  showQC={showQC}
-                />
-                <ReleasedSampleTable
-                  data={sampleData()}
-                  sort={sort}
-                  showQC={showQC}
-                />
+              <div className="btn-group ml-2">
+                <button
+                  type="button"
+                  className={`btn btn-sm btn-outline-primary ${
+                    phase === 'pass1a_06' ? 'active' : ''
+                  }`}
+                  onClick={togglePhase.bind(this, 'pass1a_06')}
+                >
+                  PASS1A 6-Month
+                </button>
+                <button
+                  type="button"
+                  className={`btn btn-sm btn-outline-primary ${
+                    phase === 'pass1b_06' ? 'active' : ''
+                  }`}
+                  onClick={togglePhase.bind(this, 'pass1b_06')}
+                  disabled={release === 'external'}
+                >
+                  PASS1B 6-Month
+                </button>
               </div>
             </div>
-          </div>
+          )}
         </div>
-        <div className="d-flex col-lg-3">
-          <div className="flex-fill w-100 card shadow-sm">
-            <div className="card-body">
-              <ReleasedSampleSummary
-                data={animalReleaseSamples}
-                release={release}
-                userType={userType}
-              />
+        <ReleasedSampleHighlight data={sampleData()} />
+        <div className="card-container-release-samples row mb-2">
+          <div className="d-flex col-lg-9">
+            <div className="flex-fill w-100 card shadow-sm">
+              <h5 className="card-header">
+                {userType === 'internal' && (
+                  <div className="internal-user-labels float-right">
+                    {release === 'internal' && (
+                      <span className="badge badge-success ml-3">
+                        Internal Release
+                      </span>
+                    )}
+                    {release === 'external' && (
+                      <span className="badge badge-warning ml-3">
+                        External Release
+                      </span>
+                    )}
+                    {phase === 'pass1a_06' && (
+                      <span className="badge badge-secondary ml-2">
+                        PASS1A 6-Month
+                      </span>
+                    )}
+                    {phase === 'pass1b_06' && (
+                      <span className="badge badge-secondary ml-2">
+                        PASS1B 6-Month
+                      </span>
+                    )}
+                  </div>
+                )}
+                {userType === 'external' && (
+                  <div className="external-user-labels float-right">
+                    <span className="badge badge-secondary">PASS1A 6-Month</span>
+                  </div>
+                )}
+                <div className="card-title mb-0">Overview</div>
+              </h5>
+              <div className="card-body pt-1">
+                <div className="release-sample-plot border-bottom pb-4 mb-4">
+                  <PlotControls togglePlot={togglePlot} plot={plot} />
+                  <ReleasedSamplePlot data={sampleData()} plot={plot} />
+                </div>
+                <div className="release-sample-table">
+                  <TableControls
+                    toggleSort={toggleSort}
+                    sort={sort}
+                    toggleQC={toggleQC}
+                    showQC={showQC}
+                  />
+                  <ReleasedSampleTable
+                    data={sampleData()}
+                    sort={sort}
+                    showQC={showQC}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="d-flex col-lg-3">
+            <div className="flex-fill w-100 card shadow-sm">
+              <div className="card-body">
+                <ReleasedSampleSummary
+                  data={animalReleaseSamples}
+                  release={release}
+                  userType={userType}
+                />
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </AuthContentContainer>
-  );
+      </AuthContentContainer>
+    );
+  }
+
+  return (<Redirect to="/" />);
 }
 
 Dashboard.propTypes = {
@@ -208,6 +232,9 @@ Dashboard.propTypes = {
   togglePlot: PropTypes.func.isRequired,
   toggleSort: PropTypes.func.isRequired,
   toggleQC: PropTypes.func.isRequired,
+  isAuthenticated: PropTypes.bool,
+  isFetching: PropTypes.bool,
+  isPending: PropTypes.bool,
 };
 
 Dashboard.defaultProps = {
@@ -218,10 +245,13 @@ Dashboard.defaultProps = {
   plot: 'tissue_name',
   sort: 'default',
   showQC: true,
+  isAuthentiacted: false,
+  isFetching: false,
+  isPending: false,
 };
 
 const mapStateToProps = (state) => ({
-  profile: state.auth.profile,
+   ...state.auth,
   expanded: state.sidebar.expanded,
   ...state.dashboard,
 });

--- a/src/ErrorPage/error.jsx
+++ b/src/ErrorPage/error.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
+import actions from '../Auth/authActions';
 import ContactHelpdesk from '../lib/ui/contactHelpdesk';
 
 /**
@@ -9,12 +10,17 @@ import ContactHelpdesk from '../lib/ui/contactHelpdesk';
  *
  * @returns {Object} JSX representation of the Error page.
  */
-export function ErrorPage({ isAuthenticated, profile }) {
+export function ErrorPage({ isAuthenticated, profile, logout }) {
   const hasAccess = profile.user_metadata && profile.user_metadata.hasAccess;
 
   if (isAuthenticated && hasAccess) {
-    return <Redirect to="/releases" />;
+    return <Redirect to="/dashboard" />;
   }
+
+  const handleLogout = () => {
+    logout();
+    return <Redirect to="/" />;
+  };
 
   return (
     <div className="col-md-9 col-lg-10 px-4 errorPage">
@@ -51,6 +57,15 @@ export function ErrorPage({ isAuthenticated, profile }) {
             </p>
           </div>
         </div>
+        <div className="home-link">
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="logOutBtn btn btn-primary"
+          >
+            Return home
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -61,11 +76,13 @@ ErrorPage.propTypes = {
     user_metadata: PropTypes.object,
   }),
   isAuthenticated: PropTypes.bool,
+  logout: PropTypes.func,
 };
 
 ErrorPage.defaultProps = {
   profile: {},
   isAuthenticated: false,
+  logout: null,
 };
 
 const mapStateToProps = (state) => ({
@@ -73,4 +90,8 @@ const mapStateToProps = (state) => ({
   isAuthenticated: state.auth.isAuthenticated,
 });
 
-export default connect(mapStateToProps)(ErrorPage);
+const mapDispatchToProps = (dispatch) => ({
+  logout: () => dispatch(actions.logout()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ErrorPage);

--- a/src/Footer/footer.jsx
+++ b/src/Footer/footer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
 import actions from '../Auth/authActions';
 import LoginButton from '../lib/loginButton';
 import MoTrPAClogo from '../assets/logo-motrpac.png';
@@ -18,12 +19,28 @@ export function Footer({
   isAuthenticated,
   profile,
   login,
+  logout,
 }) {
   // Function to get current copyright year
   const getCopyrightYear = () => {
     const today = new Date();
     const year = today.getFullYear();
     return year;
+  };
+
+  const handleLogout = () => {
+    logout();
+    return <Redirect to="/" />;
+  };
+
+  const LogoutButton = () => {
+    if (isAuthenticated) {
+      return (
+          <button type="button" onClick={handleLogout} className="logOutBtn btn btn-primary">
+            Log out
+          </button>
+      );
+    }
   };
 
   const hasAccess = profile.user_metadata && profile.user_metadata.hasAccess;
@@ -44,9 +61,14 @@ export function Footer({
                 <li className="nav-item navItem"><a href="/" className="nav-link">Home</a></li>
                 <li className="nav-item navItem"><a href="/team" className="nav-link">About Us</a></li>
                 <li className="nav-item navItem"><a href="/contact" className="nav-link">Contact Us</a></li>
-                <li className="nav-item navItem">
-                  <LoginButton login={login} />
-                </li>
+                {(isAuthenticated && !hasAccess) ?
+                  (<li className="nav-item navItem">
+                    <LogoutButton />
+                  </li>) :
+                  (<li className="nav-item navItem">
+                    <LoginButton login={login} />
+                  </li>)
+                }
               </ul>
             </div>
           </div>
@@ -86,11 +108,14 @@ Footer.propTypes = {
   }),
   isAuthenticated: PropTypes.bool,
   login: PropTypes.func.isRequired,
+  logout: PropTypes.func.isRequired,
 };
 
 Footer.defaultProps = {
   profile: {},
   isAuthenticated: false,
+  login: null,
+  logout: null,
 };
 
 const mapStateToProps = state => ({
@@ -100,6 +125,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   login: () => dispatch(actions.login()),
+  logout: () => dispatch(actions.logout()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Footer);

--- a/src/Navbar/navbar.jsx
+++ b/src/Navbar/navbar.jsx
@@ -102,7 +102,7 @@ export function Navbar({
     const siteName = profile.user_metadata && profile.user_metadata.siteName
       ? `, ${profile.user_metadata.siteName}` : '';
 
-    if (isAuthenticated && hasAccess) {
+    if (isAuthenticated) {
       return (
         <span className="user-logout-button">
           <img src={profile.picture} className="user-avatar" alt="avatar" />


### PR DESCRIPTION
# **Key Changes**
1. Users who are either not authenticated or don't have access to the data are now routed to the error page and not the homepage
2. This branch to address issue 92 avoids a flashing error/dashboard page upon login. 

## **To Test**
1. Create/use a user who lacks user metadata and attempt to login (either through Google Auth or username/password). You should be routed to the error page without a login button.
2. Create/use a user who does not have access to the data (either through Google Auth or username/password). You should be routed to the error page without a login button.
3. Create/use a user who does have access to the data. You should be routed to the dashboard.

To do:
1. Hide the login button on the error page, or make it so that it is a logout button?

