### PR TITLE
Connects to #104. PASS1A data embargo extension.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "auth0-js": "^9.13.2",
-    "axios": "^0.19.0",
+    "axios": "^0.21.1",
     "bootstrap": "4.4.1",
     "chart.js": "^2.9.3",
     "d3": "^5.14.2",

--- a/src/AnnouncementsPage/announcements.json
+++ b/src/AnnouncementsPage/announcements.json
@@ -96,7 +96,7 @@
         "aid": 5,
         "posted_date": "2021-01-15",
         "title": "Embargo extension",
-        "content": "Please note that the publication embargo on MoTrPAC data has been extended until release of additional control data necessary to fully control for non-exercise induced molecular changes in the current dataset. The control data has been delayed due to the COVID-19 pandemic and we apologize for any inconvenience caused. Please be sure that the consortium is hard at work to release this data to the scientific community as soon as possible. Until then, data can only be used for analyses supporting grant submissions, and not be used in abstracts, manuscripts, preprints or presentations.",
+        "content": "Please note that the publication embargo on MoTrPAC data has been extended until release of additional control data necessary to fully control for non-exercise induced molecular changes in the current dataset. The control data has been delayed due to the COVID-19 pandemic and we apologize for any inconvenience caused. Please be sure that the consortium is hard at work to release this data to the scientific community as soon as possible. Until then, data can only be used for analyses supporting grant submissions, and cannot be used in abstracts, manuscripts, preprints or presentations.",
         "metadata": {
             "target": "external",
             "tags": [

--- a/src/AnnouncementsPage/announcements.json
+++ b/src/AnnouncementsPage/announcements.json
@@ -91,5 +91,19 @@
                 "gaEventAction": "NIH Press Release"
             }
         ]
+    },
+    {
+        "aid": 5,
+        "posted_date": "2021-01-15",
+        "title": "Embargo extension",
+        "content": "Please note that the publication embargo on MoTrPAC data has been extended until release of additional control data necessary to fully control for non-exercise induced molecular changes in the current dataset. The control data has been delayed due to the COVID-19 pandemic and we apologize for any inconvenience caused. Please be sure that the consortium is hard at work to release this data to the scientific community as soon as possible. Until then, data can only be used for analyses supporting grant submissions, and not be used in abstracts, manuscripts, preprints or presentations.",
+        "metadata": {
+            "target": "external",
+            "tags": [
+                "embargo-extension"
+            ],
+            "icon": "date_range"
+        },
+        "links": []
     }
 ]

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -100,7 +100,7 @@ export function Dashboard({
               inconvenience caused. Please be sure that the consortium is hard at work to
               release this data to the scientific community as soon as possible. Until
               then, data can only be used for analyses supporting grant submissions, and
-              not be used in abstracts, manuscripts, preprints or presentations.
+              cannot be used in abstracts, manuscripts, preprints or presentations.
             </span>
             <button
               type="button"

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -90,6 +90,28 @@ export function Dashboard({
 
     return (
       <AuthContentContainer classes="Dashboard" expanded={expanded}>
+        {userType === 'external' && (
+          <div className="alert alert-warning alert-dismissible fade show d-flex align-items-center justify-content-between w-100" role="alert">
+            <span>
+              Please note that the publication embargo on MoTrPAC data has been extended
+              until release of additional control data necessary to fully control for
+              non-exercise induced molecular changes in the current dataset. The control
+              data has been delayed due to the COVID-19 pandemic and we apologize for any
+              inconvenience caused. Please be sure that the consortium is hard at work to
+              release this data to the scientific community as soon as possible. Until
+              then, data can only be used for analyses supporting grant submissions, and
+              not be used in abstracts, manuscripts, preprints or presentations.
+            </span>
+            <button
+              type="button"
+              className="close"
+              data-dismiss="alert"
+              aria-label="Close"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+        )}
         <div className="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom page-header">
           <div className="page-title">
             <h3>Summary of Animal Study Assays</h3>

--- a/src/DataAccess/dataAccessPage.jsx
+++ b/src/DataAccess/dataAccessPage.jsx
@@ -253,9 +253,10 @@ export function DataAccessPage({ isAuthenticated, profile }) {
               <strong>
                 Please note that there is a publication embargo on the MoTrPAC data until the
                 release of additional control data necessary to fully control the analysis for
-                molecular changes due to <em>e.g.</em> sampling and fasting time post
-                exercise. Until then, data can only be used for analyses supporting grant
-                submissions, and not be used in abstracts, manuscripts, preprints or presentations.
+                non-exercise induced molecular changes in the current dataset (<em>e.g.</em> changes
+                due to sampling and fasting time post exercise). Until then, data can only be used
+                for analyses supporting grant submissions, and cannot be used in abstracts,
+                manuscripts, preprints or presentations.
               </strong>
             </p>
           </div>
@@ -345,7 +346,7 @@ export function DataAccessPage({ isAuthenticated, profile }) {
                       <label className="form-check-label" htmlFor="dataUseAgreement2">
                         Data&nbsp;
                         <strong>CANNOT</strong>
-                        &nbsp;be publicly hosted or disseminated before the embargo deadline.
+                        &nbsp;be publicly hosted or disseminated before the embargo expires.
                       </label>
                     </div>
                   </div>
@@ -363,9 +364,9 @@ export function DataAccessPage({ isAuthenticated, profile }) {
                       />
                       <label className="form-check-label" htmlFor="dataUseAgreement3">
                         The embargo period for any type of publication of MoTrPAC
-                        External Release 1 data is 15 months after external release 1: through&nbsp;
-                        <strong>January 15, 2021</strong>
-                        .
+                        External Release 1 data is until release of additional control
+                        data necessary for full control of non-exercise induced
+                        molecular effects.
                       </label>
                     </div>
                   </div>
@@ -385,7 +386,7 @@ export function DataAccessPage({ isAuthenticated, profile }) {
                         Data&nbsp;
                         <strong>CAN</strong>
                         &nbsp;be used for analyses supporting grant submissions prior
-                        to the embargo deadline.
+                        to the embargo expiration.
                       </label>
                     </div>
                   </div>
@@ -402,7 +403,7 @@ export function DataAccessPage({ isAuthenticated, profile }) {
                         checked={formValues.dataUseAgreement5}
                       />
                       <label className="form-check-label" htmlFor="dataUseAgreement5">
-                        After the embargo period, Recipients and their Agents agree
+                        After the embargo expires, Recipients and their Agents agree
                         that in publications using&nbsp;
                         <strong>any</strong>
                         &nbsp;data from MoTrPAC public use data sets they will

--- a/src/DataAccess/dataAccessPage.jsx
+++ b/src/DataAccess/dataAccessPage.jsx
@@ -251,9 +251,11 @@ export function DataAccessPage({ isAuthenticated, profile }) {
               MoTrPAC Data Hub.
               {' '}
               <strong>
-                Please note that during the embargo period, until January 15th 2021, data can
-                only be used for analyses supporting grant submissions, and not be used in
-                abstracts, manuscripts, preprints or presentations.
+                Please note that there is a publication embargo on the MoTrPAC data until the
+                release of additional control data necessary to fully control the analysis for
+                molecular changes due to <em>e.g.</em> sampling and fasting time post
+                exercise. Until then, data can only be used for analyses supporting grant
+                submissions, and not be used in abstracts, manuscripts, preprints or presentations.
               </strong>
             </p>
           </div>

--- a/src/DataAccess/dataAccessPage.jsx
+++ b/src/DataAccess/dataAccessPage.jsx
@@ -327,7 +327,7 @@ export function DataAccessPage({ isAuthenticated, profile }) {
                         &nbsp;be used for&nbsp;
                         <strong>submission</strong>
                         &nbsp;of abstracts, manuscripts, preprints or
-                        presentations before the embargo deadline.
+                        presentations before the embargo expires.
                       </label>
                     </div>
                   </div>

--- a/src/ReleasePage/releasePage.jsx
+++ b/src/ReleasePage/releasePage.jsx
@@ -32,6 +32,22 @@ export function ReleasePage({ profile, expanded }) {
         classes="dataReleasePage external"
         expanded={expanded}
       >
+        <div className="alert alert-warning alert-dismissible fade show d-flex align-items-center justify-content-between w-100" role="alert">
+          <span>
+            Please note that the publication embargo on MoTrPAC data has been
+            extended until release of additional control data. The control data
+            has been delayed due to the COVID-19 pandemic and we apologize for
+            any inconvenience caused.
+          </span>
+          <button
+            type="button"
+            className="close"
+            data-dismiss="alert"
+            aria-label="Close"
+          >
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
         <div className="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 border-bottom">
           <div
             className="page-title"
@@ -78,7 +94,7 @@ export function ReleasePage({ profile, expanded }) {
         </div>
         <div className="btn-toolbar">
           <div
-            className="btn-group mr-2"
+            className="btn-group"
             role="group"
             aria-label="Release button group"
           >

--- a/src/sass/_announcementsPage.scss
+++ b/src/sass/_announcementsPage.scss
@@ -40,6 +40,10 @@
     &.marker-paper {
       color: $primary-blue;
     }
+
+    &.embargo-extension {
+      color: $accent-violet-shade-medium;
+    }
   }
 
   .announcement-header {


### PR DESCRIPTION
### Key Changes:

1. Updated embargo extension language on **Data Access** page.
2. Added embargo extension entry on **Announcements** page.
3. Added embargo extension alert UI only visible to external users on **Dashboard** page.
4. Added embargo extension alert UI only visible to external users on **Releases** page.

### Steps to test:

1. Without signing in on the data hub portal, navigate to `^/data-access` and expect to see an updated embargo language (in **bold**).
2. Then navigate to `^/announcements` and expect to see a new entry titled **"Embargo extension"**.
3. Sign in as an external user and expect to see an alert UI pertinent to the embargo extension message on the _Dashboard_.
4. Then navigate to `^/releases` and expect to see an alert UI pertinent to the embargo extension message.
5. Sign out and then sign in again as an internal user. Verify the absence of the alert UIs on the 2 pages described above.