### PR TITLE
Minor text edit in MoTrPAC-recommended citation

### DIFF
--- a/src/DataAccess/dataAccessPage.jsx
+++ b/src/DataAccess/dataAccessPage.jsx
@@ -450,7 +450,7 @@ export function DataAccessPage({ isAuthenticated, profile }) {
                   Data Release.&nbsp;
                   <em>MoTrPAC Data Hub</em>
                   . MoTrPAC Bioinformatics Center. October 15, 2019. Version 1.0.&nbsp;
-                  motrpac-data.org
+                  https://motrpac-data.org
                 </p>
                 <p className="card-text">
                   <em>Optional:</em>

--- a/src/DataAccess/dataAccessPage.jsx
+++ b/src/DataAccess/dataAccessPage.jsx
@@ -450,7 +450,7 @@ export function DataAccessPage({ isAuthenticated, profile }) {
                   Data Release.&nbsp;
                   <em>MoTrPAC Data Hub</em>
                   . MoTrPAC Bioinformatics Center. October 15, 2019. Version 1.0.&nbsp;
-                  motrpac-data.org/data-access
+                  motrpac-data.org
                 </p>
                 <p className="card-text">
                   <em>Optional:</em>


### PR DESCRIPTION
### Key Change:

1. Changing `motrpac-data.org/data-access` to `https://motrpac-data.org` in the MoTrPAC-recommended citation in the spirit of staying consistent with the email version sent to users.