### PR TITLE
Connects to #146. Releases page update.

### DIFF
--- a/src/ReleasePage/ReleaseDataTables/releaseDataTableInternal.jsx
+++ b/src/ReleasePage/ReleaseDataTables/releaseDataTableInternal.jsx
@@ -8,16 +8,17 @@ function ReleaseDataTableInternal({ release, renderDataTypeRow }) {
         <thead className="thead-dark">
           <tr className="table-head">
             <th className="col-data-type">Data type</th>
-            <th className="col-command-line-download">Command-line download</th>
             <th className="col-web-download">Web download</th>
           </tr>
         </thead>
         <tbody>
-          {release.result_files.data_types.map((item) => renderDataTypeRow(
-            release.result_files.bucket_name,
-            item,
-            release.version,
-          ))}
+          {release.result_files.data_types.map((item) =>
+            renderDataTypeRow(
+              release.result_files.bucket_name,
+              item,
+              release.version
+            )
+          )}
         </tbody>
       </table>
     </div>

--- a/src/ReleasePage/releaseDescFileExtract.jsx
+++ b/src/ReleasePage/releaseDescFileExtract.jsx
@@ -3,40 +3,39 @@ import PropTypes from 'prop-types';
 import EmailLink from '../lib/ui/emailLink';
 import ExternalLink from '../lib/ui/externalLink';
 
-function ReleaseDescFileExtract({ currentView }) {
+function ReleaseDescFileExtract({ currentView, releaseVersion }) {
   return (
     <>
-      <p className="release-description file-extraction-instruction">
-        All bundled datasets are compressed (*.tar.gz) and need to be extracted upon
-        downloading. For Mac users, double-clicking a downloaded *.tar.gz file will
-        extract it. For Windows users, use
-        {' '}
-        <ExternalLink to="https://www.winzip.com" label="WinZip" />
-        {' '}
-        or
-        {' '}
-        <ExternalLink to="https://www.7-zip.org" label="7-Zip" />
-        {' '}
-        to extract the compressed file.
-      </p>
-      {currentView === 'external'
-        ? (
-          <p className="release-description">
-            To request access to raw files of the different omics
-            data, please contact
-            {' '}
-            <EmailLink mailto="motrpac-data-requests@lists.stanford.edu" label="MoTrPAC Data Requests" />
-            {' '}
-            and specify the omics, tissues, and assays in which you are interested.
-          </p>
-        )
-        : null}
+      {(currentView === 'internal' && releaseVersion === '2.0') ||
+      currentView === 'external' ? (
+        <p className="release-description file-extraction-instruction">
+          All bundled datasets are compressed (*.tar.gz) and need to be
+          extracted upon downloading. For Mac users, double-clicking a
+          downloaded *.tar.gz file will extract it. For Windows users, use{' '}
+          <ExternalLink to="https://www.winzip.com" label="WinZip" /> or{' '}
+          <ExternalLink to="https://www.7-zip.org" label="7-Zip" /> to extract
+          the compressed file.
+        </p>
+      ) : null}
+      {currentView === 'external' ? (
+        <p className="release-description">
+          To request access to raw files of the different omics data, please
+          contact{' '}
+          <EmailLink
+            mailto="motrpac-data-requests@lists.stanford.edu"
+            label="MoTrPAC Data Requests"
+          />{' '}
+          and specify the omics, tissues, and assays in which you are
+          interested.
+        </p>
+      ) : null}
     </>
   );
 }
 
 ReleaseDescFileExtract.propTypes = {
   currentView: PropTypes.string.isRequired,
+  releaseVersion: PropTypes.string.isRequired,
 };
 
 export default ReleaseDescFileExtract;

--- a/src/ReleasePage/releaseDescReadme.jsx
+++ b/src/ReleasePage/releaseDescReadme.jsx
@@ -3,12 +3,11 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import EmailLink from '../lib/ui/emailLink';
 
-function ReleaseDescReadme({ releaseVersion, fileLocation }) {
-  if (releaseVersion === '1.2.1' || releaseVersion === '2.0') {
+function ReleaseDescReadme({ currentView, releaseVersion, fileLocation }) {
+  if (currentView === 'internal' && releaseVersion === '2.0') {
     return (
       <p className="release-description">
-        A
-        {' '}
+        A{' '}
         <a
           href={fileLocation}
           className="inline-link-with-icon"
@@ -17,23 +16,42 @@ function ReleaseDescReadme({ releaseVersion, fileLocation }) {
         >
           README
           <i className="material-icons readme-file-icon">description</i>
-        </a>
-        {' '}
-        document has been provided summarizing the data available in this release. To
-        learn more about the prior released dataset, please see the
-        {' '}
-        <Link to="/announcements" className="inline-link">recent announcement</Link>
-        . For any technical issues, please contact us at
-        {' '}
-        <EmailLink mailto="motrpac-helpdesk@lists.stanford.edu" label="MoTrPAC Helpdesk" />
+        </a>{' '}
+        document has been provided summarizing the data available in this
+        release. To learn more about the prior released dataset, please see the{' '}
+        <Link to="/announcements" className="inline-link">
+          recent announcement
+        </Link>
+        . For any technical issues, please contact us at{' '}
+        <EmailLink
+          mailto="motrpac-helpdesk@lists.stanford.edu"
+          label="MoTrPAC Helpdesk"
+        />
+      </p>
+    );
+  }
+
+  if (currentView === 'internal' && releaseVersion !== '2.0') {
+    return (
+      <p className="release-description">
+        Please refer to the{' '}
+        <a
+          href={fileLocation}
+          className="inline-link-with-icon"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          README
+          <i className="material-icons readme-file-icon">description</i>
+        </a>{' '}
+        document for the data available in this release.
       </p>
     );
   }
 
   return (
     <p className="release-description">
-      A
-      {' '}
+      A{' '}
       <a
         href={fileLocation}
         className="inline-link-with-icon"
@@ -42,21 +60,24 @@ function ReleaseDescReadme({ releaseVersion, fileLocation }) {
       >
         README
         <i className="material-icons readme-file-icon">description</i>
-      </a>
-      {' '}
-      document has been provided detailing the different data types available
-      in this release in addition to how to access them. For updates on known
-      issues with the initial dataset, please see our
-      {' '}
-      <Link to="/announcements" className="inline-link">recent announcement</Link>
-      . For any technical issues, please contact us at
-      {' '}
-      <EmailLink mailto="motrpac-helpdesk@lists.stanford.edu" label="MoTrPAC Helpdesk" />
+      </a>{' '}
+      document has been provided detailing the different data types available in
+      this release in addition to how to access them. For updates on known
+      issues with the initial dataset, please see our{' '}
+      <Link to="/announcements" className="inline-link">
+        recent announcement
+      </Link>
+      . For any technical issues, please contact us at{' '}
+      <EmailLink
+        mailto="motrpac-helpdesk@lists.stanford.edu"
+        label="MoTrPAC Helpdesk"
+      />
     </p>
   );
 }
 
 ReleaseDescReadme.propTypes = {
+  currentView: PropTypes.string.isRequired,
   releaseVersion: PropTypes.string.isRequired,
   fileLocation: PropTypes.string.isRequired,
 };

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -41,7 +41,7 @@ function ReleaseEntry({ profile, currentView }) {
     message: '',
     releaseVersion: null,
   });
-  const [visibleReleases, setVisibleReleases] = useState(2);
+  const [visibleReleases, setVisibleReleases] = useState(1);
 
   const releases = releaseData.filter(
     (release) => release.target === currentView
@@ -51,7 +51,7 @@ function ReleaseEntry({ profile, currentView }) {
   // Event handler for "Show prior releases" button
   const toggleViewReleaseLength = (e) => {
     e.preventDefault();
-    setVisibleReleases(visibleReleases === 2 ? releases.length : 2);
+    setVisibleReleases(visibleReleases === 1 ? releases.length : 1);
   };
 
   // Event handler for select/deselect checkboxes
@@ -426,7 +426,7 @@ function ReleaseEntry({ profile, currentView }) {
     return (
       <>
         {entries}
-        {releases.length > 1 ? (
+        {releases.length > 0 ? (
           <div className="view-more-button-container pt-2 pt-md-0 pb-3 pb-md-0 clearfix">
             <div className="d-none d-md-block col-12 col-md-3 col-lg-2 px-md-3 pb-1 pb-md-4 pt-md-4 float-left">
               <span>&nbsp;</span>
@@ -435,15 +435,15 @@ function ReleaseEntry({ profile, currentView }) {
               <button
                 type="button"
                 className={
-                  visibleReleases === 2
+                  visibleReleases < 2
                     ? 'btn btn-secondary btn-sm'
                     : 'btn btn-danger btn-sm'
                 }
                 onClick={toggleViewReleaseLength}
               >
-                {visibleReleases === 2
+                {visibleReleases < 2
                   ? 'Show prior releases'
-                  : 'Back to recent releases'}
+                  : 'Back to latest release'}
               </button>
             </div>
           </div>

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -426,7 +426,7 @@ function ReleaseEntry({ profile, currentView }) {
     return (
       <>
         {entries}
-        {releases.length > 0 ? (
+        {releases.length > 0 && currentView === 'internal' ? (
           <div className="view-more-button-container pt-2 pt-md-0 pb-3 pb-md-0 clearfix">
             <div className="d-none d-md-block col-12 col-md-3 col-lg-2 px-md-3 pb-1 pb-md-4 pt-md-4 float-left">
               <span>&nbsp;</span>

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -325,12 +325,15 @@ function ReleaseEntry({ profile, currentView }) {
                       release.version.match(/1.0|1.1|1.2|1.2.1/g) ? (
                         <p className="font-weight-bold">
                           Note: The data in this release is no longer available
-                          for download from the Data Hub portal. Please contact{' '}
+                          for download from the Data Hub portal, but available
+                          as part of the latest release (v2.0) which includes
+                          all the raw data and most updated results. Please
+                          contact{' '}
                           <EmailLink
                             mailto="motrpac-data-requests@lists.stanford.edu"
                             label="MoTrPAC Data Requests"
                           />{' '}
-                          if you need access to the data.
+                          if you need access to the data in this release.
                         </p>
                       ) : null}
                       <p className="release-description">

--- a/src/ReleasePage/releases.json
+++ b/src/ReleasePage/releases.json
@@ -196,12 +196,12 @@
     "documentation": false
   },
   {
-    "label": "Release 1.2.1",
-    "emoji": "tada",
+    "label": "Release 1.2.1 (Outdated)",
+    "emoji": null,
     "version": "1.2.1",
     "date": "May 1, 2020",
     "target": "internal",
-    "description": "This is an interim internal release of the PASS1B 6M phenotypic data. The previous PASS1A 6M phenotypic data is available for download as part of the Release 1.2  data below.",
+    "description": "This is an interim internal release of the PASS1B 6M phenotypic data. The previous PASS1A 6M phenotypic data is included as part of the Release 1.2 data below.",
     "readme_file_location": "https://docs.google.com/document/d/1JjVlHeTg1ahzR06H72kxlbP1ZMaJEsqRkswVh9JweyM",
     "result_files": {
       "bucket_name": "motrpac-internal-release1-2-results",
@@ -323,12 +323,12 @@
     "documentation": false
   },
   {
-    "label": "Release 1.2",
-    "emoji": "zap",
+    "label": "Release 1.2 (Outdated)",
+    "emoji": null,
     "version": "1.2",
     "date": "October 15, 2019",
     "target": "internal",
-    "description": "This is an internal patch release containing the complete set of phenotype data released to the BIC by DMAQC. Web download is not available to RRBS due to large file sizes. You may choose to download different bundled assay quantitative results and the phenotypic data separately, or all of them together using command-line.",
+    "description": "This is an internal patch release containing the complete set of phenotype data released to the BIC by DMAQC. The data files available in this release include metadata, QC and quantitative results, phenotypic data, raw and intermediate files of genomics, epigenomics, transcriptomics, metabolomics and proteomics.",
     "readme_file_location": "https://docs.google.com/document/d/1ExXyt_HiscTOgF9eDq-KrdcE6V2jAqTEKDfQdfHJPlU",
     "result_files": {
       "bucket_name": "motrpac-internal-release1-2-results",
@@ -420,12 +420,12 @@
     "documentation": false
   },
   {
-    "label": "Release 1.1",
-    "emoji": "sparkles",
+    "label": "Release 1.1 (Outdated)",
+    "emoji": null,
     "version": "1.1",
     "date": "September 13, 2019",
     "target": "internal",
-    "description": "This is an internal patch release containing updated metabolomics and proteomics data from 6-month old rats. Web download is not available to RRBS due to large file sizes. You may choose to download different bundled assay quantitative results and the phenotypic data separately, or all of them together using command-line.",
+    "description": "This is an internal patch release containing updated metabolomics and proteomics data from 6-month old rats. The data files available in this release include metadata, QC and quantitative results, phenotypic data, raw and intermediate files of genomics, epigenomics, transcriptomics, metabolomics and proteomics.",
     "readme_file_location": "https://docs.google.com/document/d/1t0mZvhMwd2zYxGN84qg7H_8ORQTFoLTqIwYIjWOOdBY",
     "result_files": {
       "bucket_name": "motrpac-internal-release1-1-results",
@@ -522,7 +522,7 @@
     "version": "1.0",
     "date": "August 30, 2019",
     "target": "internal",
-    "description": "The early internal release consists of acute exercise data from 6-month old rats. Web download is not available to RRBS due to large file sizes. You may choose to download different bundled assay quantitative results and the phenotypic data separately, or all of them together using command-line.",
+    "description": "This early internal release consists of acute exercise data from 6-month old rats. The data files available in this release include metadata, QC and quantitative results, phenotypic data, raw and intermediate files of genomics, epigenomics, transcriptomics, metabolomics and proteomics.",
     "readme_file_location": "https://docs.google.com/document/d/1l-RtUNQr-FtC0aYe6rUXgJb_i5ZeWQiLp9nEjCl0QOk/",
     "result_files": {
       "bucket_name": "motrpac-internal-release1-results",

--- a/src/ReleasePage/releases.json
+++ b/src/ReleasePage/releases.json
@@ -328,7 +328,7 @@
     "version": "1.2",
     "date": "October 15, 2019",
     "target": "internal",
-    "description": "This is an internal patch release containing the complete set of phenotype data released to the BIC by DMAQC. The data files available in this release include metadata, QC and quantitative results, phenotypic data, raw and intermediate files of genomics, epigenomics, transcriptomics, metabolomics and proteomics.",
+    "description": "This is an internal patch release containing the complete set of PASS1A 6M phenotype data released to the BIC by DMAQC. The data files available in this release include metadata, QC and quantitative results, phenotypic data, raw and intermediate files of genomics, epigenomics, transcriptomics, metabolomics and proteomics.",
     "readme_file_location": "https://docs.google.com/document/d/1ExXyt_HiscTOgF9eDq-KrdcE6V2jAqTEKDfQdfHJPlU",
     "result_files": {
       "bucket_name": "motrpac-internal-release1-2-results",
@@ -425,7 +425,7 @@
     "version": "1.1",
     "date": "September 13, 2019",
     "target": "internal",
-    "description": "This is an internal patch release containing updated metabolomics and proteomics data from 6-month old rats. The data files available in this release include metadata, QC and quantitative results, phenotypic data, raw and intermediate files of genomics, epigenomics, transcriptomics, metabolomics and proteomics.",
+    "description": "This is an internal patch release containing updated PASS1A metabolomics and proteomics data from 6-month old rats. The data files available in this release include metadata, QC and quantitative results, phenotypic data, raw and intermediate files of genomics, epigenomics, transcriptomics, metabolomics and proteomics.",
     "readme_file_location": "https://docs.google.com/document/d/1t0mZvhMwd2zYxGN84qg7H_8ORQTFoLTqIwYIjWOOdBY",
     "result_files": {
       "bucket_name": "motrpac-internal-release1-1-results",
@@ -522,7 +522,7 @@
     "version": "1.0",
     "date": "August 30, 2019",
     "target": "internal",
-    "description": "This early internal release consists of acute exercise data from 6-month old rats. The data files available in this release include metadata, QC and quantitative results, phenotypic data, raw and intermediate files of genomics, epigenomics, transcriptomics, metabolomics and proteomics.",
+    "description": "This early internal release consists of PASS1A acute exercise data from 6-month old rats. The data files available in this release include metadata, QC and quantitative results, phenotypic data, raw and intermediate files of genomics, epigenomics, transcriptomics, metabolomics and proteomics.",
     "readme_file_location": "https://docs.google.com/document/d/1l-RtUNQr-FtC0aYe6rUXgJb_i5ZeWQiLp9nEjCl0QOk/",
     "result_files": {
       "bucket_name": "motrpac-internal-release1-results",

--- a/src/sass/dataRelease/_releasePage.scss
+++ b/src/sass/dataRelease/_releasePage.scss
@@ -162,6 +162,11 @@
                 &:focus {
                   outline: none;
                 }
+
+                &.disabled {
+                  color: $gray;
+                  cursor: not-allowed;
+                }
               }
 
               .file-size {


### PR DESCRIPTION
### Key Changes:

Suppressed the data download links and CLI instructions for the older versions of internal data releases on the **Releases** page. This change does not affect the latest internal data release (v2.0) nor the external data release (v1.0).

### Technical Notes:

1. Prior to reviewing/testing the branch, run `nvm use v14.15.4`.
2. Also, run `rm -fr node_modules/` and `rm -f yarn.lock`. Then run `yarn install`.
3. Create a `.env` file at the root of the local repo working copy and add `ESLINT_NO_DEV_ERRORS=true`.
4. Then run `yarn sass` and `yarn start` next.

### Steps to test:

1. Sign into your test instance of the Data Hub portal and go to the `^/releases` page.
2. Scroll to the bottom of the page and click on the gray **"Show prior releases"** button.
3. Expect to see all the direct data download links being disabled, and the CLI download instructions/references being removed from the page.
4. Expect to see the direct data download links and CLI instructions to remain unchanged and functional as expected for the **Internal Release 2.0** and the **External Release 1.0**.
5. Expect to see the links to the README files of various _outdated_ releases to remain unchanged.
6. Expect to see **notes/messages** being shown in various _outdated_ releases regarding data download unavailability.