### PR TITLE
Connects to #161. Gene-centric view page bug.

### DIFF
--- a/src/AnalysisPage/GeneCentricViewRat/geneCentricSearchResultFilters.jsx
+++ b/src/AnalysisPage/GeneCentricViewRat/geneCentricSearchResultFilters.jsx
@@ -11,6 +11,7 @@ function GeneCentricSearchResultFilters({
   geneSearchParams,
   handleGeneCentricSearch,
   geneSearchChangeFilter,
+  geneSearchInputValue,
 }) {
   // FIXME - this is a hack to get the search filters such as tissue and assay
   // to render accordingly to the ktype (gene)
@@ -79,7 +80,7 @@ function GeneCentricSearchResultFilters({
           className="btn btn-sm btn-primary"
           onClick={(e) => {
             e.preventDefault();
-            handleGeneCentricSearch(geneSearchParams);
+            handleGeneCentricSearch(geneSearchParams, geneSearchInputValue);
           }}
         >
           Update results
@@ -93,6 +94,7 @@ GeneCentricSearchResultFilters.propTypes = {
   geneSearchParams: PropTypes.shape({ ...geneSearchParamsPropType }).isRequired,
   handleGeneCentricSearch: PropTypes.func.isRequired,
   geneSearchChangeFilter: PropTypes.func.isRequired,
+  geneSearchInputValue: PropTypes.string.isRequired,
 };
 
 export default GeneCentricSearchResultFilters;

--- a/src/AnalysisPage/GeneCentricViewRat/geneCentricViewPage.jsx
+++ b/src/AnalysisPage/GeneCentricViewRat/geneCentricViewPage.jsx
@@ -118,6 +118,7 @@ function GeneCentricView({
                     geneSearchParams={geneSearchParams}
                     handleGeneCentricSearch={handleGeneCentricSearch}
                     geneSearchChangeFilter={geneSearchChangeFilter}
+                    geneSearchInputValue={geneSearchInputValue}
                   />
                 </div>
                 <div className="search-results-content-container col-md-9">


### PR DESCRIPTION
### Key Changes:

Patched a bug introduced to the Gene-Centric View page, in which clicking the filters' **Update results** button upon receiving the search results from the top-level gene search would caused an error.