### PR TITLE
Fix to increase number of returned results from ElasticSearch

### DIFF
--- a/src/BrowseDataPage/browseDataActions.js
+++ b/src/BrowseDataPage/browseDataActions.js
@@ -275,6 +275,7 @@ function handleDataFetch() {
     filters: {
       phase: 'PASS1B-06',
     },
+    size: 5000,
   };
   return (dispatch) => {
     dispatch(dataFetchRequested());


### PR DESCRIPTION
### Key Changes:

Add `size` param to initial data fetch of **Browse Data** to return results beyond the default `10`.