### PR TITLE
Fix to increase number of returned results from ElasticSearch for Gene Centric View

### DIFF
--- a/src/AnalysisPage/analysisReducer.js
+++ b/src/AnalysisPage/analysisReducer.js
@@ -35,6 +35,7 @@ export const defaultGeneSearchParams = {
     'p_value_male',
     'p_value_female',
   ],
+  size: 25000,
   debug: false,
   save: false,
 };


### PR DESCRIPTION
### Key Changes:

Add `size` param to initial data fetch of **Gene Centric View** to return results beyond the default `10`.