### PR TITLE
Connects to #194. Informing users the status of data from prior consortium releases.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "react-redux": "^7.2.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "5.0.1",
-    "react-spring": "^8.0.20",
     "react-table": "^7.7.0",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",

--- a/src/BrowseDataPage/browseDataFilter.jsx
+++ b/src/BrowseDataPage/browseDataFilter.jsx
@@ -7,7 +7,7 @@ function BrowseDataFilter({ activeFilters, onChangeFilter, onResetFilters }) {
     <div key={item.name} className="card filter-module mb-4">
       <div className="card-header font-weight-bold d-flex align-items-center">
         <div>{item.name}</div>
-        {item.keyName === 'category' && (
+        {item.keyName === 'category' && item.name === 'Category' && (
           <div className="data-filter-info-icon-wrapper d-flex align-items-center">
             <i className="material-icons data-filter-info-icon ml-1">info</i>
             <span className="tooltip-on-right" id="data-filter-info-tooltip">

--- a/src/BrowseDataPage/browseDataFilter.jsx
+++ b/src/BrowseDataPage/browseDataFilter.jsx
@@ -5,7 +5,24 @@ import browseDataFilters from '../lib/browseDataFilters';
 function BrowseDataFilter({ activeFilters, onChangeFilter, onResetFilters }) {
   const filters = browseDataFilters.map((item) => (
     <div key={item.name} className="card filter-module mb-4">
-      <div className="card-header font-weight-bold">{item.name}</div>
+      <div className="card-header font-weight-bold d-flex align-items-center">
+        <div>{item.name}</div>
+        {item.keyName === 'category' && (
+          <div className="data-filter-info-icon-wrapper d-flex align-items-center">
+            <i className="material-icons data-filter-info-icon ml-1">info</i>
+            <span className="tooltip-on-right" id="data-filter-info-tooltip">
+              <span>
+                <strong>Analysis</strong> - Differential analysis and normalized
+                data tables.
+                <br />
+                <strong>Results</strong> - Quantitative results,
+                experimental/sample metadata, and QA/QC reports.
+              </span>
+              <i />
+            </span>
+          </div>
+        )}
+      </div>
       <div className="card-body">
         {item.filters.map((filter) => {
           const isActiveFilter =

--- a/src/BrowseDataPage/browseDataPage.jsx
+++ b/src/BrowseDataPage/browseDataPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
@@ -20,11 +20,19 @@ export function BrowseDataPage({
   downloadRequestResponse,
   waitingForResponse,
 }) {
+  const [showMoreSummary, setShowMoreSummary] = useState(false);
+
   // Send users to default page if they are not consortium members
   const userType = profile.user_metadata && profile.user_metadata.userType;
   if (userType === 'external') {
     return <Redirect to="/home" />;
   }
+
+  // Event handler for "Show prior releases" button
+  const toggleShowMoreSummary = (e) => {
+    e.preventDefault();
+    setShowMoreSummary(!showMoreSummary);
+  };
 
   return (
     <AuthContentContainer classes="browseDataPage" expanded={expanded}>
@@ -33,15 +41,77 @@ export function BrowseDataPage({
           <h3 className="mb-0">Browse Data</h3>
         </div>
       </div>
-      <div className="my-4">
-        Browse and download the PASS1B 6-month processed data by tissue, assay,
-        or omics. The available files include molecular and phenotypic data.
-        While raw data is not available for download through the data hub
-        portal, it can be accessed through command-line. Please contact{' '}
-        <a href="mailto:motrpac-data-requests@lists.stanford.edu">
-          MoTrPAC Data Requests
-        </a>{' '}
-        if you need access to the raw data.
+      <div className="mt-3 mb-4 browse-data-summary pb-3 border-bottom">
+        <span className="emphasis font-weight-bold">
+          Browse and download the experimental data of 6-month old rats by
+          tissue, assay, or omics. The files accessible and downloadable on this
+          page consist of a variety of data types for the animal phase focusing
+          on defining molecular changes that occur in rats after up to 8 weeks
+          of endurance training (PASS1B):
+        </span>
+        <ul className="mt-1 mb-2">
+          <li>Assay-specific differential analysis and normalized data</li>
+          <li>
+            Assay-specific quantitative results, experiment metadata, and QA/QC
+            reports
+          </li>
+          <li>
+            Cross-platform merged metabolomics data tables for named metabolites
+          </li>
+          <li>Phenotypic data</li>
+        </ul>
+        <div className="collapse mb-2" id="collapseSummary">
+          <span className="emphasis font-weight-bold">
+            The current version of the 6-month old rat data for endurance
+            training also include:
+          </span>
+          <ul className="mt-1 mb-2">
+            <li>
+              All PASS1B 6-month experimental/sample metadata from the very last
+              consortium release
+            </li>
+            <li>
+              Updated PASS1B 6-month phenotypic data since the very last
+              consortium release
+            </li>
+            <li>
+              Experimental data of additional tissues and assays not available
+              in the very last consortium release
+            </li>
+          </ul>
+          While the raw files are not available for direct download through the
+          Data Hub portal, they can be accessed through command-line with
+          granted permission. Please contact{' '}
+          <a href="mailto:motrpac-data-requests@lists.stanford.edu">
+            MoTrPAC Data Requests
+          </a>{' '}
+          if you need access to the raw files. A{' '}
+          <a
+            href="https://docs.google.com/document/d/1bdXcYQLZ65GpJKTjf9XwRxhrfHJSD9NIqCxhG6icL8U"
+            className="inline-link-with-icon"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            README
+            <i className="material-icons readme-file-icon">description</i>
+          </a>{' '}
+          document is available for reference on the data included in the very
+          last consortium release.
+        </div>
+        <button
+          className="btn btn-link btn-sm show-more-link d-flex align-items-center"
+          type="button"
+          data-toggle="collapse"
+          data-target="#collapseSummary"
+          aria-expanded="false"
+          aria-controls="collapseSummary"
+          onClick={toggleShowMoreSummary}
+        >
+          <span>Show {!showMoreSummary ? 'more' : 'less'}</span>
+          <i className="material-icons">
+            {!showMoreSummary ? 'expand_more' : 'expand_less'}
+          </i>
+        </button>
       </div>
       <div className="browse-data-container row">
         <BrowseDataFilter

--- a/src/BrowseDataPage/browseDataTable.jsx
+++ b/src/BrowseDataPage/browseDataTable.jsx
@@ -8,7 +8,8 @@ import {
   usePagination,
   useRowSelect,
 } from 'react-table';
-import browseDataPropType, {
+import {
+  browseDataPropType,
   tableColumns,
   PageIndex,
   PageSize,

--- a/src/BrowseDataPage/browseDataTable.jsx
+++ b/src/BrowseDataPage/browseDataTable.jsx
@@ -95,7 +95,7 @@ function DataTable({
       initialState: {
         pageIndex: 0,
         pageSize: 50,
-        pageCount: 59,
+        pageCount: Math.ceil(data / 50),
         sortBy: [{ id: 'tissue_name', desc: false }],
       },
     },
@@ -133,7 +133,6 @@ function DataTable({
     getTableProps,
     getTableBodyProps,
     headerGroups,
-    rows,
     prepareRow,
     preGlobalFilteredRows,
     pageOptions,
@@ -266,7 +265,7 @@ function DataTable({
                 ))}
               </thead>
               <tbody {...getTableBodyProps()}>
-                {rows.slice(0, pageSize).map((row) => {
+                {page.map((row) => {
                   prepareRow(row);
                   return (
                     <tr {...row.getRowProps()}>

--- a/src/BrowseDataPage/helper.jsx
+++ b/src/BrowseDataPage/helper.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 /**
  * BrowseDataTable props
  */
-const browseDataPropType = {
+export const browseDataPropType = {
   tissue_name: PropTypes.string,
   tissue_code: PropTypes.string,
   assay: PropTypes.string,
@@ -18,8 +18,6 @@ const browseDataPropType = {
   object_size: PropTypes.number,
   external_release: PropTypes.bool,
 };
-
-export default browseDataPropType;
 
 function formatBytes(bytes, decimals) {
   if (bytes === 0) return '0 Bytes';

--- a/src/LandingPage/landingPage.jsx
+++ b/src/LandingPage/landingPage.jsx
@@ -3,17 +3,12 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import Particles from 'react-particles-js';
-import { useSpring, animated } from 'react-spring';
 import { trackEvent } from '../GoogleAnalytics/googleAnalytics';
 import LogoAnimation from '../assets/LandingPageGraphics/LogoAnimation_03082019-yellow_pipelineball_left.gif';
 import LayerRunner from '../assets/LandingPageGraphics/Data_Layer_Runner.png';
 import HealthyHeart from '../assets/LandingPageGraphics/Infographic_Healthy_Heart.png';
 import ContactHelpdesk from '../lib/ui/contactHelpdesk';
 import onVisibilityChange from '../lib/utils/pageVisibility';
-
-// react-spring mouse parallax config
-const calc = (x, y) => [x - window.innerWidth / 2, y - window.innerHeight / 2];
-const trans3d = (x, y) => `translate3d(${x / 6}px,${y / 16}px,0)`;
 
 /**
  * Renders the landing page in unauthenticated state.
@@ -63,13 +58,6 @@ export function LandingPage({ isAuthenticated, profile }) {
       );
     };
   });
-
-  // react-spring set animation values
-  const [values, set] = useSpring(() => ({
-    xy: [0, 0],
-    config: { mass: 10, tension: 550, friction: 140 },
-  }));
-  const { xy } = values;
 
   // Redirect authenticated users to protected route
   const hasAccess = profile.user_metadata && profile.user_metadata.hasAccess;
@@ -240,20 +228,12 @@ export function LandingPage({ isAuthenticated, profile }) {
       <section>
         <div className="container featurette multi-omics" id="multi-omics">
           <div className="row featurette-wrapper h-100">
-            <div
-              className="feature-image col-12 col-md-6 mx-auto"
-              onMouseMove={({ clientX: x, clientY: y }) => set({ xy: calc(x, y) })}
-            >
-              <animated.div
-                className="animated-image-container"
-                style={{ transform: xy.interpolate(trans3d) }}
-              >
-                <img
-                  src={LayerRunner}
-                  className="img-fluid data-layer-runner"
-                  alt="Data Layer Runner"
-                />
-              </animated.div>
+            <div className="feature-image col-12 col-md-6 mx-auto">
+              <img
+                src={LayerRunner}
+                className="img-fluid data-layer-runner"
+                alt="Data Layer Runner"
+              />
             </div>
             <div className="content col-12 col-md-6">
               <h3>Multi-Omics</h3>

--- a/src/ReleasePage/ReleaseDataTables/releaseDataTableInternalByPhase.jsx
+++ b/src/ReleasePage/ReleaseDataTables/releaseDataTableInternalByPhase.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 
 function ReleaseDataTableInternalByPhase({ release, renderDataTypeRow }) {
   return (
@@ -22,6 +23,14 @@ function ReleaseDataTableInternalByPhase({ release, renderDataTypeRow }) {
         </tbody>
       </table>
       <h6>Phase: PASS1B 6-month</h6>
+      <p className="release-description">
+        Note: The PASS1B 6-month data sets included in this consortium release are now
+        outdated. Please visit the{' '}
+        <Link to="/browse-data" className="inline-link">
+          Browse Data
+        </Link>
+        {' '}page to download the most up-to-date PASS1B 6-month data.
+      </p>
       <table className="table table-sm release-data-links-table">
         <thead className="thead-dark">
           <tr className="table-head">

--- a/src/ReleasePage/ReleaseDataTables/releaseDataTableInternalByPhase.jsx
+++ b/src/ReleasePage/ReleaseDataTables/releaseDataTableInternalByPhase.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 
 function ReleaseDataTableInternalByPhase({ release, renderDataTypeRow }) {
   return (
@@ -15,22 +14,16 @@ function ReleaseDataTableInternalByPhase({ release, renderDataTypeRow }) {
           </tr>
         </thead>
         <tbody>
-          {release.result_files.data_types.pass1a_06.map((item) => renderDataTypeRow(
-            release.result_files.bucket_name,
-            item,
-            release.version,
-          ))}
+          {release.result_files.data_types.pass1a_06.map((item) =>
+            renderDataTypeRow(
+              release.result_files.bucket_name,
+              item,
+              release.version
+            )
+          )}
         </tbody>
       </table>
       <h6>Phase: PASS1B 6-month</h6>
-      <p className="release-description">
-        Note: The PASS1B 6-month data sets included in this consortium release are now
-        outdated. Please visit the{' '}
-        <Link to="/browse-data" className="inline-link">
-          Browse Data
-        </Link>
-        {' '}page to download the most up-to-date PASS1B 6-month data.
-      </p>
       <table className="table table-sm release-data-links-table">
         <thead className="thead-dark">
           <tr className="table-head">
@@ -40,11 +33,13 @@ function ReleaseDataTableInternalByPhase({ release, renderDataTypeRow }) {
           </tr>
         </thead>
         <tbody>
-          {release.result_files.data_types.pass1b_06.map((item) => renderDataTypeRow(
-            release.result_files.bucket_name,
-            item,
-            release.version,
-          ))}
+          {release.result_files.data_types.pass1b_06.map((item) =>
+            renderDataTypeRow(
+              release.result_files.bucket_name,
+              item,
+              release.version
+            )
+          )}
         </tbody>
       </table>
     </div>

--- a/src/ReleasePage/ReleaseDataTables/releaseDataTableInternalByPhase.jsx
+++ b/src/ReleasePage/ReleaseDataTables/releaseDataTableInternalByPhase.jsx
@@ -9,7 +9,6 @@ function ReleaseDataTableInternalByPhase({ release, renderDataTypeRow }) {
         <thead className="thead-dark">
           <tr className="table-head">
             <th className="col-data-type">Data type</th>
-            <th className="col-command-line-download">Command-line download</th>
             <th className="col-web-download">Web download</th>
           </tr>
         </thead>
@@ -28,7 +27,6 @@ function ReleaseDataTableInternalByPhase({ release, renderDataTypeRow }) {
         <thead className="thead-dark">
           <tr className="table-head">
             <th className="col-data-type">Data type</th>
-            <th className="col-command-line-download">Command-line download</th>
             <th className="col-web-download">Web download</th>
           </tr>
         </thead>

--- a/src/ReleasePage/releaseDescFileExtract.jsx
+++ b/src/ReleasePage/releaseDescFileExtract.jsx
@@ -1,41 +1,17 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import EmailLink from '../lib/ui/emailLink';
-import ExternalLink from '../lib/ui/externalLink';
 
-function ReleaseDescFileExtract({ currentView, releaseVersion }) {
+function ReleaseDescFileExtract() {
   return (
-    <>
-      {(currentView === 'internal' && releaseVersion === '2.0') ||
-      currentView === 'external' ? (
-        <p className="release-description file-extraction-instruction">
-          All bundled datasets are compressed (*.tar.gz) and need to be
-          extracted upon downloading. For Mac users, double-clicking a
-          downloaded *.tar.gz file will extract it. For Windows users, use{' '}
-          <ExternalLink to="https://www.winzip.com" label="WinZip" /> or{' '}
-          <ExternalLink to="https://www.7-zip.org" label="7-Zip" /> to extract
-          the compressed file.
-        </p>
-      ) : null}
-      {currentView === 'external' ? (
-        <p className="release-description">
-          To request access to raw files of the different omics data, please
-          contact{' '}
-          <EmailLink
-            mailto="motrpac-data-requests@lists.stanford.edu"
-            label="MoTrPAC Data Requests"
-          />{' '}
-          and specify the omics, tissues, and assays in which you are
-          interested.
-        </p>
-      ) : null}
-    </>
+    <p className="release-description">
+      To request access to raw files of the different omics data, please contact{' '}
+      <EmailLink
+        mailto="motrpac-data-requests@lists.stanford.edu"
+        label="MoTrPAC Data Requests"
+      />{' '}
+      and specify the omics, tissues, and assays in which you are interested.
+    </p>
   );
 }
-
-ReleaseDescFileExtract.propTypes = {
-  currentView: PropTypes.string.isRequired,
-  releaseVersion: PropTypes.string.isRequired,
-};
 
 export default ReleaseDescFileExtract;

--- a/src/ReleasePage/releaseDescFileExtract.jsx
+++ b/src/ReleasePage/releaseDescFileExtract.jsx
@@ -1,16 +1,28 @@
 import React from 'react';
 import EmailLink from '../lib/ui/emailLink';
+import ExternalLink from '../lib/ui/externalLink';
 
 function ReleaseDescFileExtract() {
   return (
-    <p className="release-description">
-      To request access to raw files of the different omics data, please contact{' '}
-      <EmailLink
-        mailto="motrpac-data-requests@lists.stanford.edu"
-        label="MoTrPAC Data Requests"
-      />{' '}
-      and specify the omics, tissues, and assays in which you are interested.
-    </p>
+    <>
+      <p className="release-description file-extraction-instruction">
+        All bundled datasets are compressed (*.tar.gz) and need to be extracted
+        upon downloading. For Mac users, double-clicking a downloaded *.tar.gz
+        file will extract it. For Windows users, use{' '}
+        <ExternalLink to="https://www.winzip.com" label="WinZip" /> or{' '}
+        <ExternalLink to="https://www.7-zip.org" label="7-Zip" /> to extract the
+        compressed file.
+      </p>
+      <p className="release-description">
+        To request access to raw files of the different omics data, please
+        contact{' '}
+        <EmailLink
+          mailto="motrpac-data-requests@lists.stanford.edu"
+          label="MoTrPAC Data Requests"
+        />{' '}
+        and specify the omics, tissues, and assays in which you are interested.
+      </p>
+    </>
   );
 }
 

--- a/src/ReleasePage/releaseDescReadme.jsx
+++ b/src/ReleasePage/releaseDescReadme.jsx
@@ -3,35 +3,8 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import EmailLink from '../lib/ui/emailLink';
 
-function ReleaseDescReadme({ currentView, releaseVersion, fileLocation }) {
-  if (currentView === 'internal' && releaseVersion === '2.0') {
-    return (
-      <p className="release-description">
-        A{' '}
-        <a
-          href={fileLocation}
-          className="inline-link-with-icon"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          README
-          <i className="material-icons readme-file-icon">description</i>
-        </a>{' '}
-        document has been provided summarizing the data available in this
-        release. To learn more about the prior released dataset, please see the{' '}
-        <Link to="/announcements" className="inline-link">
-          recent announcement
-        </Link>
-        . For any technical issues, please contact us at{' '}
-        <EmailLink
-          mailto="motrpac-helpdesk@lists.stanford.edu"
-          label="MoTrPAC Helpdesk"
-        />
-      </p>
-    );
-  }
-
-  if (currentView === 'internal' && releaseVersion !== '2.0') {
+function ReleaseDescReadme({ currentView, fileLocation }) {
+  if (currentView === 'internal') {
     return (
       <p className="release-description">
         Please refer to the{' '}
@@ -78,7 +51,6 @@ function ReleaseDescReadme({ currentView, releaseVersion, fileLocation }) {
 
 ReleaseDescReadme.propTypes = {
   currentView: PropTypes.string.isRequired,
-  releaseVersion: PropTypes.string.isRequired,
   fileLocation: PropTypes.string.isRequired,
 };
 

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -1,11 +1,10 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
 import axios from 'axios';
 import { trackEvent } from '../GoogleAnalytics/googleAnalytics';
 import IconSet from '../lib/iconSet';
-import ToolTip from '../lib/ui/tooltip';
 import EmailLink from '../lib/ui/emailLink';
-import ExternalLink from '../lib/ui/externalLink';
 import ReleaseDescFileExtract from './releaseDescFileExtract';
 import ReleaseDescReadme from './releaseDescReadme';
 import ReleaseRawFilesDownload from './releaseRawFilesDownload';
@@ -16,11 +15,7 @@ import ReleaseDataTableExternal from './ReleaseDataTables/releaseDataTableExtern
 const releaseData = require('./releases.json');
 
 const emojiMap = {
-  rocket: '🚀',
-  sparkles: '✨',
-  zap: '⚡️',
   tada: '🎉',
-  dna: '🧬',
 };
 
 /**
@@ -41,7 +36,7 @@ function ReleaseEntry({ profile, currentView }) {
     message: '',
     releaseVersion: null,
   });
-  const [visibleReleases, setVisibleReleases] = useState(1);
+  const [visibleReleases, setVisibleReleases] = useState(0);
 
   const releases = releaseData.filter(
     (release) => release.target === currentView
@@ -51,7 +46,7 @@ function ReleaseEntry({ profile, currentView }) {
   // Event handler for "Show prior releases" button
   const toggleViewReleaseLength = (e) => {
     e.preventDefault();
-    setVisibleReleases(visibleReleases === 1 ? releases.length : 1);
+    setVisibleReleases(visibleReleases === 0 ? releases.length : 0);
   };
 
   // Event handler for select/deselect checkboxes
@@ -64,56 +59,6 @@ function ReleaseEntry({ profile, currentView }) {
       el.classList.add('active');
       el.innerHTML = 'check_box';
     }
-  }
-
-  // Render intermediate files download section content
-  function renderIntermediateFilesDownloadSectionContent(files) {
-    return (
-      <div className="card mb-3">
-        <div className="card-body">
-          <p className="card-text">
-            Due to the large sizes of intermediate data files, we recommend users
-            who wish to download intermediate files using the
-            {' '}
-            <ExternalLink to="https://cloud.google.com/storage/docs/quickstart-gsutil" label="gsutil command" />
-            . Below are example commands for downloading intermediate files of different omics.
-          </p>
-          <p className="card-text">
-            Intermediate files of genomics, epigenomics and transcriptomic:
-            <code>{`gsutil -m cp -r gs://${files.get.bucket_name}/* .`}</code>
-          </p>
-          <p className="card-text">
-            Intermediate files of metabolomics:
-            <code>{`gsutil -m cp -r gs://${files.metabolomics.bucket_name}/* .`}</code>
-          </p>
-          <p className="card-text">
-            Intermediate files of proteomics:
-            <code>{`gsutil -m cp -r gs://${files.proteomics.bucket_name}/* .`}</code>
-          </p>
-        </div>
-      </div>
-    );
-  }
-
-  // Render tooltip content on copy-to-clipboard hover
-  function renderTooltipContent(objectPath, data) {
-    return (
-      <div>
-        <code id={data}>{`gsutil -m cp -r ${objectPath}`}</code>
-        <span>Copy to clipboard</span>
-      </div>
-    );
-  }
-
-  // Handle 'copy to clipboard' click event
-  function handleCopyClick(path, data) {
-    const command = document.querySelector(`#${data}`).innerHTML;
-    const tempInput = document.createElement('INPUT');
-    document.body.appendChild(tempInput);
-    tempInput.setAttribute('value', command);
-    tempInput.select();
-    document.execCommand('copy');
-    document.body.removeChild(tempInput);
   }
 
   // Fetch file url from Google Storage API
@@ -204,10 +149,6 @@ function ReleaseEntry({ profile, currentView }) {
 
   // Render data type row
   function renderDataTypeRow(bucket, item, version) {
-    const objectPath =
-      item.type === 'all'
-        ? `gs://${bucket}/${item.object_zipfile} .`
-        : `gs://${bucket}${item.object_path}/* .`;
     return (
       <tr key={`${item.type}-${version}`}>
         <td>
@@ -216,34 +157,9 @@ function ReleaseEntry({ profile, currentView }) {
             <span>{item.title}</span>
           </div>
         </td>
-        {currentView === 'internal' && version === '2.0' ? (
-          <td className="release-data-download-link">
-            <div className="copy-to-clipboard-wrapper">
-              {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
-              <span
-                role="button"
-                tabIndex="-1"
-                className="copy-to-clipboard-button"
-                onClick={handleCopyClick.bind(
-                  this,
-                  objectPath,
-                  item.tooltip_id
-                )}
-              >
-                <i className="material-icons release-data-download-icon">
-                  file_copy
-                </i>
-              </span>
-              <ToolTip
-                content={renderTooltipContent(objectPath, item.tooltip_id)}
-              />
-            </div>
-          </td>
-        ) : null}
         {item.object_zipfile && item.object_zipfile.length ? (
           <td className="release-data-download-link">
-            {(currentView === 'internal' && version === '2.0') ||
-            currentView === 'external' ? (
+            {currentView === 'external' ? (
               <button
                 type="button"
                 className="btn-data-download"
@@ -285,15 +201,16 @@ function ReleaseEntry({ profile, currentView }) {
   // Render individual release entry
   function renderReleaseEntry() {
     let entries;
+    const defaultEntries = currentView === 'external' ? 1 : visibleReleases;
     if (releases && releases.length) {
       // eslint-disable-next-line arrow-body-style
-      entries = releases.slice(0, visibleReleases).map((release, idx) => {
+      entries = releases.slice(0, defaultEntries).map((release, idx) => {
         return (
           <div key={release.version} className={`release-entry-container ${currentView}`}>
             <div className="release-entry-item pt-2 pt-md-0 pb-3 pb-md-0 clearfix label-latest">
               {/* release timeline marker */}
               <div className="d-none d-md-block flex-wrap flex-items-center col-12 col-md-3 col-lg-2 px-md-3 pb-1 pb-md-4 pt-md-4 float-left text-md-right v-align-top release-timeline">
-                {idx < 1
+                {idx < 1 && currentView === 'external'
                   ? (
                     <div className="flex-auto flex-self-start">
                       <span className={`badge ${currentView === 'internal' ? 'badge-success' : 'badge-warning'}`}>Latest release</span>
@@ -332,14 +249,13 @@ function ReleaseEntry({ profile, currentView }) {
                 <div className="release-content mb-3">
                   <div className="card mb-3">
                     <div className="card-body">
-                      {currentView === 'internal' &&
-                      release.version.match(/1.0|1.1|1.2|1.2.1/g) ? (
+                      {currentView === 'internal' ? (
                         <p className="font-weight-bold">
-                          Note: The data in this release is no longer available
-                          for download from the Data Hub portal, but available
-                          as part of the latest release (v2.0) which includes
-                          all the raw data and most updated results. Please
-                          contact{' '}
+                          Note: The data in this release is outdated and no
+                          longer available for download from the Data Hub
+                          portal. Please visit the{' '}
+                          <Link to="/browse-data">Browse Data</Link> page for
+                          the most up-to-date PASS1A and PASS1B data. Contact{' '}
                           <EmailLink
                             mailto="motrpac-data-requests@lists.stanford.edu"
                             label="MoTrPAC Data Requests"
@@ -350,13 +266,11 @@ function ReleaseEntry({ profile, currentView }) {
                       <p className="release-description">
                         {release.description}
                       </p>
-                      <ReleaseDescFileExtract
-                        currentView={currentView}
-                        releaseVersion={release.version}
-                      />
+                      {currentView === 'external' ? (
+                        <ReleaseDescFileExtract />
+                      ) : null}
                       <ReleaseDescReadme
                         currentView={currentView}
-                        releaseVersion={release.version}
                         fileLocation={release.readme_file_location}
                       />
                       {currentView === 'internal' &&
@@ -386,46 +300,6 @@ function ReleaseEntry({ profile, currentView }) {
                       {renderModal()}
                     </div>
                   </div>
-                  {currentView === 'internal' &&
-                  release.raw_files &&
-                  release.version === '2.0' ? (
-                    <>
-                      <h6 className="additional-release-download-header">
-                        Additional Downloads
-                      </h6>
-                      <div className="raw-files-download-section">
-                        <p className="d-block mb-2 d-flex align-items-center justify-content-start raw-files-download-option">
-                          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
-                          <i
-                            role="button"
-                            tabIndex="-1"
-                            className="material-icons download-checkbox"
-                            data-toggle="collapse"
-                            data-target={`#raw-files-release-${idx}`}
-                            aria-expanded="false"
-                            aria-controls={`raw-files-release-${idx}`}
-                            id={`raw-files-release-${idx}-checkbox`}
-                            onClick={handleCheckboxEvent.bind(
-                              this,
-                              `raw-files-release-${idx}-checkbox`
-                            )}
-                          >
-                            check_box_outline_blank
-                          </i>
-                          <span>Raw and intermediate files downloads</span>
-                        </p>
-                        <div
-                          className="collapse"
-                          id={`raw-files-release-${idx}`}
-                        >
-                          <ReleaseRawFilesDownload
-                            releaseVersion={release.version}
-                            files={release.raw_files}
-                          />
-                        </div>
-                      </div>
-                    </>
-                  ) : null}
                 </div>
               </div>
             </div>
@@ -436,6 +310,31 @@ function ReleaseEntry({ profile, currentView }) {
 
     return (
       <>
+        {releases.length > 0 && currentView === 'internal' ? (
+          <div className="release-data-status-info-container clearfix">
+            <div className="d-none d-md-block col-12 col-md-3 col-lg-2 px-md-3 pb-1 pb-md-4 pt-md-4 float-left">
+              <span>&nbsp;</span>
+            </div>
+            <div className="release-data-status-info pt-3 pb-4 col-12 col-md-9 col-lg-10 float-left">
+              The data sets included in prior consortium releases on this page
+              are now outdated. Please visit the{' '}
+              <Link to="/browse-data">Browse Data</Link> page to view or
+              download the most up-to-date PASS1B 6-month data. The up-to-date
+              PASS1A/1C 6-month data will be soon made available to the
+              consortium community. To learn more about the prior released data
+              sets, please visit the{' '}
+              <Link to="/announcements" className="inline-link">
+                Announcements
+              </Link>{' '}
+              page. Contact the{' '}
+              <EmailLink
+                mailto="motrpac-helpdesk@lists.stanford.edu"
+                label="MoTrPAC Helpdesk"
+              />{' '}
+              if you have any questions concerning the data in prior releases.
+            </div>
+          </div>
+        ) : null}
         {entries}
         {releases.length > 0 && currentView === 'internal' ? (
           <div className="view-more-button-container pt-2 pt-md-0 pb-3 pb-md-0 clearfix">
@@ -446,13 +345,13 @@ function ReleaseEntry({ profile, currentView }) {
               <button
                 type="button"
                 className={
-                  visibleReleases < 2
+                  visibleReleases < 1
                     ? 'btn btn-secondary btn-sm'
                     : 'btn btn-danger btn-sm'
                 }
                 onClick={toggleViewReleaseLength}
               >
-                {visibleReleases < 2
+                {visibleReleases < 1
                   ? 'Show prior releases'
                   : 'Back to latest release'}
               </button>

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -216,32 +216,45 @@ function ReleaseEntry({ profile, currentView }) {
       // eslint-disable-next-line arrow-body-style
       entries = releases.slice(0, defaultEntries).map((release, idx) => {
         return (
-          <div key={release.version} className={`release-entry-container ${currentView}`}>
+          <div
+            key={release.version}
+            className={`release-entry-container ${currentView}`}
+          >
             <div className="release-entry-item pt-2 pt-md-0 pb-3 pb-md-0 clearfix label-latest">
               {/* release timeline marker */}
               <div className="d-none d-md-block flex-wrap flex-items-center col-12 col-md-3 col-lg-2 px-md-3 pb-1 pb-md-4 pt-md-4 float-left text-md-right v-align-top release-timeline">
-                {idx < 1 && currentView === 'external'
-                  ? (
-                    <div className="flex-auto flex-self-start">
-                      <span className={`badge ${currentView === 'internal' ? 'badge-success' : 'badge-warning'}`}>Latest release</span>
-                    </div>
-                  )
-                  : null}
+                {idx < 1 && currentView === 'external' ? (
+                  <div className="flex-auto flex-self-start">
+                    <span
+                      className={`badge ${
+                        currentView === 'internal'
+                          ? 'badge-success'
+                          : 'badge-warning'
+                      }`}
+                    >
+                      Latest release
+                    </span>
+                  </div>
+                ) : null}
                 <ul className="d-none d-md-block mt-2 list-style-none">
                   <li className="d-block mb-1 d-flex align-items-center justify-content-end">
-                    <i className="material-icons release-version-marker-icon">local_offer</i>
+                    <i className="material-icons release-version-marker-icon">
+                      local_offer
+                    </i>
                     <span className="release-version-marker">{`v${release.version}`}</span>
                   </li>
-                  {userType === 'internal'
-                    ? (
-                      <li className="d-block mb-1 d-flex align-items-center justify-content-end">
-                        <i className="material-icons release-version-marker-icon">local_offer</i>
-                        <span className="release-view">{currentView}</span>
-                      </li>
-                    )
-                    : null}
+                  {userType === 'internal' ? (
+                    <li className="d-block mb-1 d-flex align-items-center justify-content-end">
+                      <i className="material-icons release-version-marker-icon">
+                        local_offer
+                      </i>
+                      <span className="release-view">{currentView}</span>
+                    </li>
+                  ) : null}
                   <li className="d-block mb-1 d-flex align-items-center justify-content-end">
-                    <i className="material-icons release-date-marker-icon">calendar_today</i>
+                    <i className="material-icons release-date-marker-icon">
+                      calendar_today
+                    </i>
                     <span className="release-date">{release.date}</span>
                   </li>
                 </ul>
@@ -249,11 +262,11 @@ function ReleaseEntry({ profile, currentView }) {
               {/* release content */}
               <div className="col-12 col-md-9 col-lg-10 pl-md-3 py-md-4 release-main-section float-left">
                 <h2 className="release-header">
-                  {release.emoji
-                    ? (
-                      <span role="img" aria-label={release.emoji}>{`${emojiMap[release.emoji]} `}</span>
-                    )
-                    : null}
+                  {release.emoji ? (
+                    <span role="img" aria-label={release.emoji}>{`${
+                      emojiMap[release.emoji]
+                    } `}</span>
+                  ) : null}
                   {release.label}
                 </h2>
                 <div className="release-content mb-3">

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -112,21 +112,44 @@ function ReleaseEntry({ profile, currentView }) {
   // Render modal
   function renderModal() {
     return (
-      <div className="modal fade data-download-modal" id="dataDownloadModal" tabIndex="-1" role="dialog" aria-labelledby="dataDownloadModalLabel" aria-hidden="true">
+      <div
+        className="modal fade data-download-modal"
+        id="dataDownloadModal"
+        tabIndex="-1"
+        role="dialog"
+        aria-labelledby="dataDownloadModalLabel"
+        aria-hidden="true"
+      >
         <div className="modal-dialog modal-dialog-centered" role="document">
           <div className="modal-content">
             <div className="modal-header">
               <h5 className="modal-title">File Download</h5>
-              <button type="button" className="close" data-dismiss="modal" aria-label="Close">
+              <button
+                type="button"
+                className="close"
+                data-dismiss="modal"
+                aria-label="Close"
+              >
                 <span aria-hidden="true">&times;</span>
               </button>
             </div>
             <div className="modal-body">
-              {!fetching
-                ? renderModalMessage() : <div className="loading-spinner"><img src={IconSet.Spinner} alt="" /></div>}
+              {!fetching ? (
+                renderModalMessage()
+              ) : (
+                <div className="loading-spinner">
+                  <img src={IconSet.Spinner} alt="" />
+                </div>
+              )}
             </div>
             <div className="modal-footer">
-              <button type="button" className="btn btn-secondary" data-dismiss="modal">Close</button>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                data-dismiss="modal"
+              >
+                Close
+              </button>
             </div>
           </div>
         </div>

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -7,7 +7,6 @@ import IconSet from '../lib/iconSet';
 import EmailLink from '../lib/ui/emailLink';
 import ReleaseDescFileExtract from './releaseDescFileExtract';
 import ReleaseDescReadme from './releaseDescReadme';
-import ReleaseRawFilesDownload from './releaseRawFilesDownload';
 import ReleaseDataTableInternalByPhase from './ReleaseDataTables/releaseDataTableInternalByPhase';
 import ReleaseDataTableInternal from './ReleaseDataTables/releaseDataTableInternal';
 import ReleaseDataTableExternal from './ReleaseDataTables/releaseDataTableExternal';
@@ -48,18 +47,6 @@ function ReleaseEntry({ profile, currentView }) {
     e.preventDefault();
     setVisibleReleases(visibleReleases === 0 ? releases.length : 0);
   };
-
-  // Event handler for select/deselect checkboxes
-  function handleCheckboxEvent(target) {
-    const el = document.querySelector(`#${target}`);
-    if (el.classList.contains('active')) {
-      el.classList.remove('active');
-      el.innerHTML = 'check_box_outline_blank';
-    } else {
-      el.classList.add('active');
-      el.innerHTML = 'check_box';
-    }
-  }
 
   // Fetch file url from Google Storage API
   function fetchFile(bucket, filename, version) {

--- a/src/ReleasePage/releases.json
+++ b/src/ReleasePage/releases.json
@@ -5,7 +5,7 @@
     "version": "2.0",
     "date": "June 30, 2020",
     "target": "internal",
-    "description": "The second major internal data release is now available through the MoTrPAC data hub. This release includes the majority of the PASS1A and PASS1B molecular and phenotypic data. Processed data is available for Web download and through the command-line, while raw data is available through the command-line only.",
+    "description": "This is the second major internal data release through the MoTrPAC data hub. It includes the majority of the PASS1A and PASS1B molecular and phenotypic data.",
     "readme_file_location": "https://docs.google.com/document/d/1bdXcYQLZ65GpJKTjf9XwRxhrfHJSD9NIqCxhG6icL8U",
     "result_files": {
       "bucket_name": "motrpac-internal-release2-results",

--- a/src/ReleasePage/releases.json
+++ b/src/ReleasePage/releases.json
@@ -1,7 +1,7 @@
 [
   {
-    "label": "Release 2.0",
-    "emoji": "rocket",
+    "label": "Release 2.0 (Outdated)",
+    "emoji": null,
     "version": "2.0",
     "date": "June 30, 2020",
     "target": "internal",

--- a/src/lib/browseDataFilters.jsx
+++ b/src/lib/browseDataFilters.jsx
@@ -55,7 +55,7 @@ const browseDataFilters = [
     filters: ['Analysis', 'Results'],
   },
   {
-    keyName: 'metadata',
+    keyName: 'category',
     name: 'Metadata',
     filters: ['Phenotype'],
   },

--- a/src/lib/browseDataFilters.jsx
+++ b/src/lib/browseDataFilters.jsx
@@ -52,7 +52,12 @@ const browseDataFilters = [
   {
     keyName: 'category',
     name: 'Category',
-    filters: ['Analysis', 'Results', 'Phenotype'],
+    filters: ['Analysis', 'Results'],
+  },
+  {
+    keyName: 'metadata',
+    name: 'Metadata',
+    filters: ['Phenotype'],
   },
 ];
 

--- a/src/lib/browseDataFilters.jsx
+++ b/src/lib/browseDataFilters.jsx
@@ -33,11 +33,6 @@ const browseDataFilters = [
     filters: tissueList,
   },
   {
-    keyName: 'assay',
-    name: 'Assay',
-    filters: assayList,
-  },
-  {
     keyName: 'omics',
     name: 'Omics',
     filters: [
@@ -48,6 +43,11 @@ const browseDataFilters = [
       'Proteomics Untargeted',
       'Transcriptomics',
     ],
+  },
+  {
+    keyName: 'assay',
+    name: 'Assay',
+    filters: assayList,
   },
   {
     keyName: 'category',

--- a/src/sass/_landingPage.scss
+++ b/src/sass/_landingPage.scss
@@ -144,7 +144,12 @@ section {
       text-align: center;
 
       img {
-        height: 26.0rem;
+        height: 24.5rem;
+        transition: height 0.5s ease;
+
+        &:hover {
+          height: 26.5rem;
+        }
       }
     }
   }

--- a/src/sass/analysis/_geneCentricResults.scss
+++ b/src/sass/analysis/_geneCentricResults.scss
@@ -233,6 +233,11 @@
     .material-icons {
       color: #888;
     }
+
+    &:first-child input {
+      pointer-events: none;
+      cursor: not-allowed;
+    }
   }
 
   tbody {

--- a/src/sass/browseData/_browseData.scss
+++ b/src/sass/browseData/_browseData.scss
@@ -1,4 +1,25 @@
 .browseDataPage {
+  .browse-data-summary {
+    font-size: 0.9rem;
+
+    .show-more-link {
+      font-size: 0.9rem;
+      font-weight: normal;
+      color: #007bff;
+      padding: 0;
+
+      &:hover {
+        text-decoration: none;
+      }
+
+      &:focus, &:active {
+        box-shadow: none;
+        outline: none;
+        text-decoration: none;
+      }
+    }
+  }
+
   label {
     font-size: inherit;
     line-height: 1;

--- a/src/sass/browseData/_browseData.scss
+++ b/src/sass/browseData/_browseData.scss
@@ -111,6 +111,12 @@
       .card-header {
         font-size: 0.9rem;
         padding: 0.4rem 0.85rem;
+
+        .data-filter-info-icon {
+          color: $gray;
+          font-size: 1.1rem;
+          cursor: pointer;
+        }
       }
 
       .card-body {
@@ -190,5 +196,20 @@
         background-color: #f3f3f3;
       }
     }
+  }
+}
+
+/**
+  * Category filter group panel header
+  * info icon to show/hide tooltip
+  */
+.data-filter-info-icon-wrapper {
+  position: relative;
+}
+
+.data-filter-info-icon-wrapper:hover {
+  .tooltip-on-right {
+    visibility: visible;
+    opacity: 1;
   }
 }

--- a/src/sass/browseData/_browseData.scss
+++ b/src/sass/browseData/_browseData.scss
@@ -216,6 +216,14 @@
       &.omics.not-available {
         background-color: #f3f3f3;
       }
+
+      &.category.Phenotype {
+        background-color: #f3f3f3;
+
+        span {
+          display: none;
+        }
+      }
     }
   }
 }

--- a/src/sass/dataRelease/_releasePage.scss
+++ b/src/sass/dataRelease/_releasePage.scss
@@ -231,6 +231,14 @@
       padding-right: 0;
     }
   }
+
+  .release-data-status-info-container {
+    .release-data-status-info {
+      border-left: 2px solid #e1e4e8;
+      font-size: 0.9rem;
+      padding-right: 0;
+    }
+  }
 }
 
 /* specificity for external release view */


### PR DESCRIPTION
### Key Changes:

* Updated the Releases page so that now consortium users no longer can access the prior internally released data. With the newly added note, users are now instructed to visit the Browse Data page to access the most up-to-date PASS1B-06 data.
* On the Browse Data page, the page summary at the top has been expanded so that it is now more descriptive and provides a bit context on the data.
* On the Browse Data page, the order of the Assay and Omics filter group panels have been swapped.
* On the Browse Data page, the Phenotype filter has been moved out of the Category filter group and into its own labeled Metadata.
* On the Browse Data page, an `info` icon has been added to the Category filter group panel header so that it shows/hides a tooltip given the mouseover event.
* Fixed a bug that was introduced in a prior implementation of enhancing the functionality of the checkbox in the table header of the Browse Data page. As a result of the bug, clicking the Next or Previous pagination buttons at the bottom does not change the displayed rows in the table.
* On the Gene-Centric View of the animal analysis, the checkbox in the table header (for search results) is now disabled to discourage users from selecting all rows in the table.
* On the landing page, the package-dependent animation of graphic next to Multi-Omics has been replaced with a new animation supported by CSS-only.