### PR TITLE
Connects to #204. Connects to #206. Fixes for Browse Data and Sample Summary.

### DIFF
--- a/src/BrowseDataPage/browseDataReducer.js
+++ b/src/BrowseDataPage/browseDataReducer.js
@@ -55,17 +55,40 @@ function browseDataReducer(state = defaultBrowseDataState, action) {
       }
       let filtered = state.allFiles;
 
-      // if any filters placed filters appropriately
-      Object.keys(state.activeFilters).forEach((cat) => {
-        if (newActiveFilters[cat].length) {
-          filtered = filtered.filter(
-            (file) =>
-              newActiveFilters[cat].findIndex((el) =>
-                el.includes(file[cat])
-              ) !== -1 || file[cat] === 'Merged'
-          );
-        }
-      });
+      // Select a filter in either tissue or assay should
+      // return a subset of matching files
+      // FIXME: need to optimize the workaround to return
+      // merged metabolomics (not assay-specific) files
+      if (
+        action.category === 'assay' &&
+        action.filter.match(/Targeted|Untargeted/)
+      ) {
+        // return all metabolomics files, including merged
+        // (not specific to any one assay) files
+        Object.keys(state.activeFilters).forEach((cat) => {
+          if (newActiveFilters[cat].length) {
+            filtered = filtered.filter(
+              (file) =>
+                newActiveFilters[cat].findIndex((el) =>
+                  el.includes(file[cat])
+                ) !== -1 || file[cat] === 'Merged'
+            );
+          }
+        });
+      } else {
+        // return matching files, excluding metabolomics
+        // merged files
+        Object.keys(state.activeFilters).forEach((cat) => {
+          if (newActiveFilters[cat].length) {
+            filtered = filtered.filter(
+              (file) =>
+                newActiveFilters[cat].findIndex((el) =>
+                  el.includes(file[cat])
+                ) !== -1
+            );
+          }
+        });
+      }
 
       return {
         ...state,

--- a/src/data/animal_release_samples.json
+++ b/src/data/animal_release_samples.json
@@ -2348,7 +2348,7 @@
                         "assay_code": "transcript-rna-seq",
                         "assay_name": "RNA-seq",
                         "omics_code": "transcriptomics",
-                        "count": 78,
+                        "count": 39,
                         "qc_count": null
                     },
                     {
@@ -2528,7 +2528,7 @@
                         "assay_code": "transcript-rna-seq",
                         "assay_name": "RNA-seq",
                         "omics_code": "transcriptomics",
-                        "count": 78,
+                        "count": 39,
                         "qc_count": null
                     },
                     {


### PR DESCRIPTION
### Key Changes:

* On the **Browse Data** page, selecting a **non-metabolomics** assay filter would result in a set of files with **merged** metabolomics data included. This has now been addressed with a workaround.
* On the **Sample Summary** page, the sample counts for **PASS1A-06 RNA-seq** _testes_ and _ovaries_ tissues have now been corrected to 39.