### PR TITLE
Connects to #210. Search user experience enhancement.

### DIFF
--- a/src/AnalysisPage/GeneCentricViewRat/geneCentricSearchResultFilters.jsx
+++ b/src/AnalysisPage/GeneCentricViewRat/geneCentricSearchResultFilters.jsx
@@ -27,13 +27,11 @@ function GeneCentricSearchResultFilters({
     );
   }
 
-  geneCentricSearchFilters.find(
-    (f) => f.keyName === 'tissue'
-  ).filters = customizeTissueList();
+  geneCentricSearchFilters.find((f) => f.keyName === 'tissue').filters =
+    customizeTissueList();
 
-  geneCentricSearchFilters.find(
-    (f) => f.keyName === 'assay'
-  ).filters = customizeAssayList();
+  geneCentricSearchFilters.find((f) => f.keyName === 'assay').filters =
+    customizeAssayList();
 
   const commonSearchResultFilters = geneCentricSearchFilters.map((item) => (
     <div key={item.name} className="card filter-module mb-4">
@@ -80,7 +78,11 @@ function GeneCentricSearchResultFilters({
           className="btn btn-sm btn-primary"
           onClick={(e) => {
             e.preventDefault();
-            handleGeneCentricSearch(geneSearchParams, geneSearchInputValue);
+            handleGeneCentricSearch(
+              geneSearchParams,
+              geneSearchInputValue,
+              'filters'
+            );
           }}
         >
           Update results

--- a/src/AnalysisPage/GeneCentricViewRat/geneCentricSearchResultFilters.jsx
+++ b/src/AnalysisPage/GeneCentricViewRat/geneCentricSearchResultFilters.jsx
@@ -12,6 +12,7 @@ function GeneCentricSearchResultFilters({
   handleGeneCentricSearch,
   geneSearchChangeFilter,
   geneSearchInputValue,
+  enabledFilters,
 }) {
   // FIXME - this is a hack to get the search filters such as tissue and assay
   // to render accordingly to the ktype (gene)
@@ -46,6 +47,10 @@ function GeneCentricSearchResultFilters({
               geneSearchParams.filters[item.keyName].indexOf(
                 filter.filter_value
               ) > -1;
+            const isDisabledFilter =
+              enabledFilters[item.keyName] &&
+              Object.keys(enabledFilters[item.keyName]).length &&
+              !enabledFilters[item.keyName][filter.filter_value.toLowerCase()];
             return (
               <button
                 key={filter.filter_label}
@@ -53,9 +58,11 @@ function GeneCentricSearchResultFilters({
                 className={`btn filterBtn ${
                   isActiveFilter ? 'activeFilter' : ''
                 }`}
-                onClick={() =>
-                  geneSearchChangeFilter(item.keyName, filter.filter_value)
-                }
+                onClick={() => {
+                  if (isDisabledFilter) return false;
+                  geneSearchChangeFilter(item.keyName, filter.filter_value);
+                }}
+                disabled={isDisabledFilter}
               >
                 {filter.filter_label}
               </button>
@@ -97,6 +104,14 @@ GeneCentricSearchResultFilters.propTypes = {
   handleGeneCentricSearch: PropTypes.func.isRequired,
   geneSearchChangeFilter: PropTypes.func.isRequired,
   geneSearchInputValue: PropTypes.string.isRequired,
+  enabledFilters: PropTypes.shape({
+    assay: PropTypes.object,
+    tissue: PropTypes.object,
+  }),
+};
+
+GeneCentricSearchResultFilters.defaultProps = {
+  enabledFilters: {},
 };
 
 export default GeneCentricSearchResultFilters;

--- a/src/AnalysisPage/GeneCentricViewRat/geneCentricViewPage.jsx
+++ b/src/AnalysisPage/GeneCentricViewRat/geneCentricViewPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import AnalysisActions from '../analysisActions';
 import { defaultGeneSearchParams } from '../analysisReducer';
 import GeneCentricTrainingResultsTable from './geneCentricTrainingResultsTable';
@@ -17,6 +18,7 @@ function GeneCentricView({
   handleGeneCentricSearch,
   geneSearchReset,
   geneSearchChangeFilter,
+  scope,
 }) {
   // Function to map array of keys to each array of values for each row
   function mapKeyToValue(indexObj) {
@@ -80,7 +82,8 @@ function GeneCentricView({
                     e.preventDefault();
                     handleGeneCentricSearch(
                       geneSearchParams,
-                      geneSearchInputValue
+                      geneSearchInputValue,
+                      'all'
                     );
                   }}
                 >
@@ -105,13 +108,16 @@ function GeneCentricView({
             ) : null}
             {!geneSearching &&
             !geneSearchResults.result &&
-            geneSearchResults.errors ? (
+            geneSearchResults.errors &&
+            scope === 'all' ? (
               <div className="alert alert-warning">
                 {geneSearchResults.errors} Please modify the gene symbol and try
                 again.
               </div>
             ) : null}
-            {!geneSearching && geneSearchResults.result ? (
+            {!geneSearching &&
+            (geneSearchResults.result ||
+              (geneSearchResults.errors && scope === 'filters')) ? (
               <div className="search-results-wrapper-container row">
                 <div className="search-sidebar-container col-md-3">
                   <GeneCentricSearchResultFilters
@@ -122,11 +128,30 @@ function GeneCentricView({
                   />
                 </div>
                 <div className="search-results-content-container col-md-9">
-                  <GeneCentricTrainingResultsTable
-                    trainingData={trainingResults}
-                    timewiseData={timewiseResults}
-                    geneSymbol={geneSearchParams.keys}
-                  />
+                  {trainingResults.length ? (
+                    <GeneCentricTrainingResultsTable
+                      trainingData={trainingResults}
+                      timewiseData={timewiseResults}
+                      geneSymbol={geneSearchParams.keys}
+                    />
+                  ) : (
+                    scope === 'filters' && (
+                      <p className="mt-4">
+                        {geneSearchResults.errors &&
+                        geneSearchResults.errors.indexOf('No results found') !==
+                          -1 ? (
+                          <span>
+                            No matches found for the selected filters. Please
+                            refer to the{' '}
+                            <Link to="/summary">Summary Table</Link> for data
+                            that are available.
+                          </span>
+                        ) : (
+                          geneSearchResults.errors
+                        )}
+                      </p>
+                    )
+                  )}
                 </div>
               </div>
             ) : null}
@@ -161,6 +186,7 @@ GeneCentricView.propTypes = {
   handleGeneCentricSearch: PropTypes.func.isRequired,
   geneSearchReset: PropTypes.func.isRequired,
   geneSearchChangeFilter: PropTypes.func.isRequired,
+  scope: PropTypes.string,
 };
 
 GeneCentricView.defaultProps = {
@@ -169,6 +195,7 @@ GeneCentricView.defaultProps = {
   geneSearching: false,
   genSearchError: '',
   geneSearchParams: { ...defaultGeneSearchParams },
+  scope: 'all',
 };
 
 const mapStateToProps = (state) => ({
@@ -178,8 +205,10 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => ({
   geneSearchInputChange: (geneInputValue) =>
     dispatch(AnalysisActions.geneSearchInputChange(geneInputValue)),
-  handleGeneCentricSearch: (params, geneInputValue) =>
-    dispatch(AnalysisActions.handleGeneCentricSearch(params, geneInputValue)),
+  handleGeneCentricSearch: (params, geneInputValue, scope) =>
+    dispatch(
+      AnalysisActions.handleGeneCentricSearch(params, geneInputValue, scope)
+    ),
   geneSearchReset: () => dispatch(AnalysisActions.geneSearchReset()),
   geneSearchChangeFilter: (field, value) =>
     dispatch(AnalysisActions.geneSearchChangeFilter(field, value)),

--- a/src/AnalysisPage/GeneCentricViewRat/geneCentricViewPage.jsx
+++ b/src/AnalysisPage/GeneCentricViewRat/geneCentricViewPage.jsx
@@ -19,6 +19,7 @@ function GeneCentricView({
   geneSearchReset,
   geneSearchChangeFilter,
   scope,
+  enabledFilters,
 }) {
   // Function to map array of keys to each array of values for each row
   function mapKeyToValue(indexObj) {
@@ -125,6 +126,7 @@ function GeneCentricView({
                     handleGeneCentricSearch={handleGeneCentricSearch}
                     geneSearchChangeFilter={geneSearchChangeFilter}
                     geneSearchInputValue={geneSearchInputValue}
+                    enabledFilters={enabledFilters}
                   />
                 </div>
                 <div className="search-results-content-container col-md-9">
@@ -187,6 +189,10 @@ GeneCentricView.propTypes = {
   geneSearchReset: PropTypes.func.isRequired,
   geneSearchChangeFilter: PropTypes.func.isRequired,
   scope: PropTypes.string,
+  enabledFilters: PropTypes.shape({
+    assay: PropTypes.object,
+    tissue: PropTypes.object,
+  }),
 };
 
 GeneCentricView.defaultProps = {
@@ -196,6 +202,7 @@ GeneCentricView.defaultProps = {
   genSearchError: '',
   geneSearchParams: { ...defaultGeneSearchParams },
   scope: 'all',
+  enabledFilters: {},
 };
 
 const mapStateToProps = (state) => ({

--- a/src/AnalysisPage/analysisActions.js
+++ b/src/AnalysisPage/analysisActions.js
@@ -46,9 +46,10 @@ function geneSearchInputChange(geneInputValue = '') {
   };
 }
 
-function geneSearchSubmit() {
+function geneSearchSubmit(scope) {
   return {
     type: GENE_SEARCH_SUBMIT,
+    scope,
   };
 }
 
@@ -97,10 +98,10 @@ const headersConfig = {
 };
 
 // Handle gene-centric search
-function handleGeneCentricSearch(params, geneInputValue) {
+function handleGeneCentricSearch(params, geneInputValue, scope) {
   params.keys = geneInputValue;
   return (dispatch) => {
-    dispatch(geneSearchSubmit());
+    dispatch(geneSearchSubmit(scope));
     return axios
       .post(`${host}${endpoint}`, params, headersConfig)
       .then((response) => {

--- a/src/AnalysisPage/analysisReducer.js
+++ b/src/AnalysisPage/analysisReducer.js
@@ -35,6 +35,7 @@ export const defaultGeneSearchParams = {
     'p_value_male',
     'p_value_female',
   ],
+  unique_fields: ['tissue', 'assay'],
   size: 25000,
   save: false,
 };
@@ -59,6 +60,7 @@ export const defaultAnalysisState = {
   geneSearching: false,
   geneSearchError: '',
   scope: 'all',
+  enabledFilters: {},
 };
 
 export default function AnalysisReducer(
@@ -148,6 +150,9 @@ export default function AnalysisReducer(
               }
             : action.geneSearchResults,
         geneSearching: false,
+        enabledFilters: action.geneSearchResults.uniqs
+          ? action.geneSearchResults.uniqs
+          : state.enabledFilters,
       };
     // Revert param values to default
     case GENE_SEARCH_RESET: {
@@ -164,6 +169,7 @@ export default function AnalysisReducer(
         geneSearching: false,
         geneSearchError: '',
         scope: 'all',
+        enabledFilters: {},
       };
     }
     // Handle secondary filters: tissue, assay

--- a/src/AnalysisPage/analysisReducer.js
+++ b/src/AnalysisPage/analysisReducer.js
@@ -149,11 +149,16 @@ export default function AnalysisReducer(
       };
     // Revert param values to default
     case GENE_SEARCH_RESET: {
+      const cloneDefaultGeneSearchParams = { ...defaultGeneSearchParams };
+      cloneDefaultGeneSearchParams.keys = '';
+      cloneDefaultGeneSearchParams.filters.assay = [];
+      cloneDefaultGeneSearchParams.filters.tissue = [];
+
       return {
         ...state,
         geneSearchInputValue: '',
         geneSearchResults: {},
-        geneSearchParams: defaultGeneSearchParams,
+        geneSearchParams: cloneDefaultGeneSearchParams,
         geneSearching: false,
         geneSearchError: '',
       };

--- a/src/AnalysisPage/analysisReducer.js
+++ b/src/AnalysisPage/analysisReducer.js
@@ -58,6 +58,7 @@ export const defaultAnalysisState = {
   geneSearchParams: defaultGeneSearchParams,
   geneSearching: false,
   geneSearchError: '',
+  scope: 'all',
 };
 
 export default function AnalysisReducer(
@@ -124,6 +125,7 @@ export default function AnalysisReducer(
         geneSearchResults: {},
         geneSearchParams: params,
         geneSearching: true,
+        scope: action.scope,
       };
     }
     // Handle form submit error
@@ -161,6 +163,7 @@ export default function AnalysisReducer(
         geneSearchParams: cloneDefaultGeneSearchParams,
         geneSearching: false,
         geneSearchError: '',
+        scope: 'all',
       };
     }
     // Handle secondary filters: tissue, assay

--- a/src/BrowseDataPage/browseDataPage.jsx
+++ b/src/BrowseDataPage/browseDataPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Redirect } from 'react-router-dom';
+import { Redirect, Link } from 'react-router-dom';
 import AuthContentContainer from '../lib/ui/authContentContainer';
 import BrowseDataTable from './browseDataTable';
 import actions from './browseDataActions';
@@ -119,7 +119,19 @@ export function BrowseDataPage({
           onChangeFilter={onChangeFilter}
           onResetFilters={onResetFilters}
         />
-        {!fetching ? (
+        {fetching && <AnimatedLoadingIcon isFetching={fetching} />}
+        {!fetching && !filteredFiles.length && (
+          <div className="browse-data-table-wrapper col-md-9">
+            <p className="mt-4">
+              <span>
+                No matches found for the selected filters. Please refer to the{' '}
+                <Link to="/summary">Summary Table</Link> for data that are
+                available.
+              </span>
+            </p>
+          </div>
+        )}
+        {!fetching && filteredFiles.length && (
           <BrowseDataTable
             filteredFiles={filteredFiles}
             handleDownloadRequest={handleDownloadRequest}
@@ -127,8 +139,6 @@ export function BrowseDataPage({
             waitingForResponse={waitingForResponse}
             profile={profile}
           />
-        ) : (
-          <AnimatedLoadingIcon isFetching={fetching} />
         )}
       </div>
     </AuthContentContainer>

--- a/src/Search/deaSearchResultFilters.jsx
+++ b/src/Search/deaSearchResultFilters.jsx
@@ -13,6 +13,7 @@ function SearchResultFilters({
   changeResultFilter,
   handleSearch,
   resetSearch,
+  enabledFilters,
 }) {
   const [inputError, setInputError] = useState(false);
   // FIXME - this is a hack to get the search filters such as tissue and assay
@@ -48,7 +49,7 @@ function SearchResultFilters({
       return assayList.filter(
         (t) =>
           !t.filter_value.match(
-            /^(transcript-rna-seq|epigen-atac-seq|epigen-rrbs|immunoassay|prot-pr|prot-ph|prot-ac|prot-ub)$/
+            /^(transcript-rna-seq|epigen-atac-seq|epigen-rrbs|immunoassay|prot-pr|prot-ph|prot-ac|prot-ub|prot-ub-protein-corrected)$/
           )
       );
     }
@@ -85,6 +86,10 @@ function SearchResultFilters({
               searchParams.filters[item.keyName] &&
               searchParams.filters[item.keyName].indexOf(filter.filter_value) >
                 -1;
+            const isDisabledFilter =
+              enabledFilters[item.keyName] &&
+              Object.keys(enabledFilters[item.keyName]).length &&
+              !enabledFilters[item.keyName][filter.filter_value.toLowerCase()];
             return (
               <button
                 key={filter.filter_label}
@@ -92,9 +97,11 @@ function SearchResultFilters({
                 className={`btn filterBtn ${
                   isActiveFilter ? 'activeFilter' : ''
                 }`}
-                onClick={() =>
-                  changeResultFilter(item.keyName, filter.filter_value, null)
-                }
+                onClick={() => {
+                  if (isDisabledFilter) return false;
+                  changeResultFilter(item.keyName, filter.filter_value, null);
+                }}
+                disabled={isDisabledFilter}
               >
                 {filter.filter_label}
               </button>
@@ -206,6 +213,16 @@ SearchResultFilters.propTypes = {
   changeResultFilter: PropTypes.func.isRequired,
   handleSearch: PropTypes.func.isRequired,
   resetSearch: PropTypes.func.isRequired,
+  enabledFilters: PropTypes.shape({
+    assay: PropTypes.object,
+    comparison_group: PropTypes.object,
+    sex: PropTypes.object,
+    tissue: PropTypes.object,
+  }),
+};
+
+SearchResultFilters.defaultProps = {
+  enabledFilters: {},
 };
 
 export default SearchResultFilters;

--- a/src/Search/searchPage.jsx
+++ b/src/Search/searchPage.jsx
@@ -36,6 +36,7 @@ export function SearchPage({
   handleQCDataFetch,
   allFiles,
   lastModified,
+  enabledFilters,
 }) {
   const userType = profile.user_metadata && profile.user_metadata.userType;
 
@@ -89,7 +90,11 @@ export function SearchPage({
             </span>
           </div>
           <div className="es-search-ui-container d-flex align-items-center w-100">
-            <RadioButton changeParam={changeParam} ktype={searchParams.ktype} />
+            <RadioButton
+              changeParam={changeParam}
+              ktype={searchParams.ktype}
+              resetSearch={resetSearch}
+            />
             <div className="search-box-input-group d-flex align-items-center flex-grow-1">
               <input
                 type="text"
@@ -160,6 +165,7 @@ export function SearchPage({
                     changeResultFilter={changeResultFilter}
                     handleSearch={handleSearch}
                     resetSearch={resetSearch}
+                    enabledFilters={enabledFilters}
                   />
                 </div>
                 <div className="tabbed-content col-md-9">
@@ -280,7 +286,7 @@ export function SearchPage({
 }
 
 // Radio buttons for selecting the search context
-function RadioButton({ changeParam, ktype }) {
+function RadioButton({ changeParam, ktype, resetSearch }) {
   return (
     <div className="search-context">
       <div className="form-check form-check-inline">
@@ -291,7 +297,10 @@ function RadioButton({ changeParam, ktype }) {
           id="inlineRadioGene"
           value="gene"
           checked={ktype === 'gene'}
-          onChange={(e) => changeParam('ktype', e.target.value)}
+          onChange={(e) => {
+            resetSearch('all');
+            changeParam('ktype', e.target.value);
+          }}
         />
         <label className="form-check-label" htmlFor="inlineRadioGene">
           Gene
@@ -305,7 +314,10 @@ function RadioButton({ changeParam, ktype }) {
           id="inlineRadioProtein"
           value="protein"
           checked={ktype === 'protein'}
-          onChange={(e) => changeParam('ktype', e.target.value)}
+          onChange={(e) => {
+            resetSearch('all');
+            changeParam('ktype', e.target.value);
+          }}
         />
         <label className="form-check-label" htmlFor="inlineRadioProtein">
           Protein ID
@@ -319,7 +331,10 @@ function RadioButton({ changeParam, ktype }) {
           id="inlineRadioMetab"
           value="metab"
           checked={ktype === 'metab'}
-          onChange={(e) => changeParam('ktype', e.target.value)}
+          onChange={(e) => {
+            resetSearch('all');
+            changeParam('ktype', e.target.value);
+          }}
         />
         <label className="form-check-label" htmlFor="inlineRadioMetabolite">
           Metabolite
@@ -499,6 +514,12 @@ SearchPage.propTypes = {
   handleQCDataFetch: PropTypes.func.isRequired,
   allFiles: PropTypes.arrayOf(PropTypes.shape({})),
   lastModified: PropTypes.string,
+  enabledFilters: PropTypes.shape({
+    assay: PropTypes.object,
+    comparison_group: PropTypes.object,
+    sex: PropTypes.object,
+    tissue: PropTypes.object,
+  }),
 };
 
 SearchPage.defaultProps = {
@@ -514,6 +535,7 @@ SearchPage.defaultProps = {
   downloadError: '',
   allFiles: [],
   lastModified: '',
+  enabledFilters: {},
 };
 
 const mapStateToProps = (state) => ({

--- a/src/Search/searchPage.jsx
+++ b/src/Search/searchPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import TimewiseResultsTable from './timewiseTable';
 import TrainingResultsTable from './trainingResultsTable';
 import AuthContentContainer from '../lib/ui/authContentContainer';
@@ -213,7 +214,20 @@ export function SearchPage({
                         />
                       ) : (
                         scope === 'filters' && (
-                          <p className="mt-4">{searchResults.errors}</p>
+                          <p className="mt-4">
+                            {searchResults.errors &&
+                            searchResults.errors.indexOf('No results found') !==
+                              -1 ? (
+                              <span>
+                                No matches found for the selected filters.
+                                Please refer to the{' '}
+                                <Link to="/summary">Summary Table</Link> for
+                                data that are available.
+                              </span>
+                            ) : (
+                              searchResults.errors
+                            )}
+                          </p>
                         )
                       )}
                     </div>
@@ -231,7 +245,20 @@ export function SearchPage({
                         />
                       ) : (
                         scope === 'filters' && (
-                          <p className="mt-4">{searchResults.errors}</p>
+                          <p className="mt-4">
+                            {searchResults.errors &&
+                            searchResults.errors.indexOf('No results found') !==
+                              -1 ? (
+                              <span>
+                                No matches found for the selected filters.
+                                Please refer to the{' '}
+                                <Link to="/summary">Summary Table</Link> for
+                                data that are available.
+                              </span>
+                            ) : (
+                              searchResults.errors
+                            )}
+                          </p>
                         )
                       )}
                     </div>

--- a/src/Search/searchReducer.js
+++ b/src/Search/searchReducer.js
@@ -42,6 +42,7 @@ export const defaultSearchState = {
       'p_value_male',
       'p_value_female',
     ],
+    unique_fields: ['tissue', 'assay', 'sex', 'comparison_group'],
     size: 25000,
     save: false,
   },
@@ -110,8 +111,16 @@ export function SearchReducer(state = { ...defaultSearchState }, action) {
 
     // Handle form submit event
     case SEARCH_SUBMIT: {
-      const { ktype, keys, omics, analysis, filters, fields, size } =
-        action.params;
+      const {
+        ktype,
+        keys,
+        omics,
+        analysis,
+        filters,
+        fields,
+        unique_fields,
+        size,
+      } = action.params;
       return {
         ...state,
         searchResults: {},
@@ -122,6 +131,7 @@ export function SearchReducer(state = { ...defaultSearchState }, action) {
           analysis,
           filters,
           fields,
+          unique_fields,
           size,
           debug: true,
           save: false,

--- a/src/Search/searchReducer.js
+++ b/src/Search/searchReducer.js
@@ -52,6 +52,7 @@ export const defaultSearchState = {
   downloadResults: {},
   downloading: false,
   downloadError: '',
+  enabledFilters: {},
 };
 
 // Reducer to handle actions sent from components related to advanced search form
@@ -161,6 +162,9 @@ export function SearchReducer(state = { ...defaultSearchState }, action) {
               }
             : action.searchResults,
         searching: false,
+        enabledFilters: action.searchResults.uniqs
+          ? action.searchResults.uniqs
+          : state.enabledFilters,
       };
 
     // Revert param/filter values to default
@@ -196,6 +200,7 @@ export function SearchReducer(state = { ...defaultSearchState }, action) {
       return {
         ...defaultSearchState,
         searchParams: defaultParams,
+        enabledFilters: {},
       };
     }
 

--- a/src/sass/search/_search.scss
+++ b/src/sass/search/_search.scss
@@ -184,6 +184,11 @@
         margin: 0.3rem;
         padding: .2rem .4rem;
         white-space: normal;
+
+        &:disabled {
+          cursor: not-allowed;
+          opacity: 0.5;
+        }
       }
 
       .activeFilter {


### PR DESCRIPTION
### Key Changes:

* Use the unique metadata in the top-level search response (e.g. gene symbol, protein id, metabolite) to disable the search filters (e.g. tissue, assay) that have no matches in the returned DEA results. This change applies to the DEA search and Gene-centric View pages.
* Display a more helpful message to users when selected search filters return no matches in the search results. This change applies to the DEA search, Gene-centric View, and Browse Data pages.
* Fixed uncaught UI behavior when user clicks on the radio buttons of either Gene or Protein ID after a top-level search. Now the click event reset top level search results. This change applies to the DEA search page only.