### PR TITLE
Connects to #218. QC Data Monitor bug.

### DIFF
--- a/src/DataStatusPage/qcReportByPhaseTabContent.jsx
+++ b/src/DataStatusPage/qcReportByPhaseTabContent.jsx
@@ -23,7 +23,7 @@ function qcReportByPhaseTabContent({ data, phases }) {
     const filteredData = {};
     Object.keys(data).forEach((key) => {
       const filteredList = data[key].filter(
-        (item) => item.phase.toUpperCase().indexOf(phase.toUpperCase()) > -1
+        (item) => item.phase.toUpperCase().indexOf(phase.toUpperCase()) > -1 && !item.raw_files_fm
       );
       filteredData[key] = filteredList;
     });


### PR DESCRIPTION
### Key Changes:

* Added condition to ignore the metabolomics/proteomics raw file entries in rendering the "tissue submission by phase" grid/matrix of the QC Data Monitor so that the instances of "T* - undefined" (e.g. "T69 - undefined") are omitted from the bottom grid labels.