### PR TITLE
Connects to #220. Search result filter bug for metabolomics assays.

### DIFF
--- a/src/Search/searchReducer.js
+++ b/src/Search/searchReducer.js
@@ -29,7 +29,6 @@ export const defaultSearchState = {
     fields: [
       'gene_symbol',
       'metabolite',
-      'dataset',
       'feature_ID',
       'tissue',
       'assay',

--- a/src/Search/sharedlib.jsx
+++ b/src/Search/sharedlib.jsx
@@ -25,7 +25,6 @@ export const searchParamsDefaultProps = {
   fields: [
     'gene_symbol',
     'metabolite',
-    'dataset',
     'feature_ID',
     'tissue',
     'assay',
@@ -79,7 +78,6 @@ export const searchParamsPropType = {
 export const timewiseResultsTablePropType = {
   gene_symbol: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   metabolite: PropTypes.string,
-  dataset: PropTypes.string,
   feature_ID: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   tissue: PropTypes.string,
   assay: PropTypes.string,
@@ -98,7 +96,6 @@ export const timewiseResultsTablePropType = {
 export const trainingResultsTablePropType = {
   gene_symbol: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   metabolite: PropTypes.string,
-  dataset: PropTypes.string,
   feature_ID: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   tissue: PropTypes.string,
   assay_name: PropTypes.string,
@@ -224,7 +221,7 @@ export const metabTimewiseTableColumns = [
   },
   {
     Header: 'Assay',
-    accessor: 'dataset',
+    accessor: 'assay',
   },
   {
     Header: 'Sex',
@@ -389,7 +386,7 @@ export const metabTrainingTableColumns = [
   },
   {
     Header: 'Assay',
-    accessor: 'dataset',
+    accessor: 'assay',
   },
   {
     Header: () => (
@@ -696,13 +693,6 @@ export const transformData = (arr) => {
       );
     }
     */
-    // Transform metabolomics dataset (aka assay) values
-    if (item.dataset && item.dataset.length) {
-      const matchedDataset = assayList.find(
-        (filter) => filter.filter_value === item.dataset
-      );
-      item.dataset = matchedDataset && matchedDataset.filter_label;
-    }
     // Transform tissue values
     if (item.tissue && item.tissue.length) {
       const matchedTissue = tissueList.find(


### PR DESCRIPTION
### Key Changes

* Removed instances of `dataset` from search params, search props, table props, and table cell value processing, all pertinent to searchable metabolomics DEA results.