### PR TITLE
Connects to #227. Reset all search filters.

### DIFF
--- a/src/AnalysisPage/analysisActions.js
+++ b/src/AnalysisPage/analysisActions.js
@@ -103,6 +103,13 @@ const headersConfig = {
 // Handle gene-centric search
 function handleGeneCentricSearch(params, geneInputValue, scope) {
   params.keys = geneInputValue;
+  // Reset all filters if scope is 'all'
+  if (scope === 'all') {
+    params.filters = {
+      assay: [],
+      tissue: [],
+    };
+  }
   return (dispatch) => {
     dispatch(geneSearchSubmit(scope, geneInputValue));
     return axios

--- a/src/AnalysisPage/analysisReducer.js
+++ b/src/AnalysisPage/analysisReducer.js
@@ -121,6 +121,14 @@ export default function AnalysisReducer(
     case GENE_SEARCH_SUBMIT: {
       const params = { ...state.geneSearchParams };
       params.keys = action.input;
+      // Reset all filters if scope is 'all'
+      if (action.scope === 'all') {
+        params.filters = {
+          assay: [],
+          tissue: [],
+        };
+      }
+
       return {
         ...state,
         geneSearchResults: {},

--- a/src/Search/searchActions.js
+++ b/src/Search/searchActions.js
@@ -96,6 +96,18 @@ const headersConfig = {
 // Handle search and results filtering events
 function handleSearch(params, inputValue, scope) {
   params.keys = inputValue;
+  // Reset all filters if scope is 'all'
+  if (scope === 'all') {
+    params.filters = {
+      tissue: [],
+      assay: [],
+      sex: [],
+      comparison_group: [],
+      adj_p_value: { min: '', max: '' },
+      logFC: { min: '', max: '' },
+      p_value: { min: '', max: '' },
+    };
+  }
   return (dispatch) => {
     dispatch(searchSubmit(params, scope));
     return axios


### PR DESCRIPTION
### Key Changes:

* When a search submit event is invoked at the top-level, all search filters are reset so that previously selected filters are not persisted. This change applies to the DEA search and Gene-centric View.