### PR TITLE
Connects to #249. Hot Fix - Search by protein id broken.

### DIFF
--- a/src/Search/searchPage.jsx
+++ b/src/Search/searchPage.jsx
@@ -222,8 +222,8 @@ export function SearchPage({
                     e.preventDefault();
                     handleSearch(
                       searchParams,
-                      multiSelections.length ||
-                        (inputEl.value && inputEl.value.length)
+                      (multiSelections && multiSelections.length) ||
+                        (inputEl && inputEl.value && inputEl.value.length)
                         ? formatSearchInput()
                         : searchParams.keys,
                       'all'


### PR DESCRIPTION
### Key Changes:

Fixed bug in the event when a protein id is entered to be searched. Clicking the **Search** button returns no results or any kind of feedback in the UI. This bug was likely introduced when implementing a prior fix to address issues in which a user manually entered a gene symbol or metabolite name.