### PR TITLE
Connects to #259. Clarity tracking code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react-tooltip": "^5.11.2",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
-    "sass": "1.63.6",
     "tsparticles": "1.36.0",
     "victory": "36.4.1"
   },
@@ -71,6 +70,7 @@
     "jest-canvas-mock": "^2.2.0",
     "prettier": "^3.0.0",
     "react-error-overlay": "^6.0.11",
+    "sass": "1.63.6",
     "storybook-react-router": "1.0.8",
     "stylelint": "^15.10.0",
     "stylelint-config-recommended": "^13.0.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-tooltip": "^5.11.2",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
+    "sass": "1.63.6",
     "tsparticles": "1.36.0",
     "victory": "36.4.1"
   },
@@ -70,7 +71,6 @@
     "jest-canvas-mock": "^2.2.0",
     "prettier": "^3.0.0",
     "react-error-overlay": "^6.0.11",
-    "sass": "^1.57.1",
     "storybook-react-router": "1.0.8",
     "stylelint": "^15.10.0",
     "stylelint-config-recommended": "^13.0.0"

--- a/public/index.html
+++ b/public/index.html
@@ -45,6 +45,15 @@
     <!-- Google Material Icons -->
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
+    <!-- Clarity tracking code -->
+    <script type="text/javascript">
+      (function(c,l,a,r,i,t,y){
+          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, "clarity", "script", "igkabpsgqm");
+    </script>
+
     <title>MoTrPAC Data Hub</title>
   </head>
   <body>


### PR DESCRIPTION
### Key Changes:

* Pinned `sass` dependency version to suppress deprecation warning of global abs() function when compiling `scss` files
* Added Clarity tracking code to `<head>` in `public.html` to collect usage stats