### PR TITLE
Connects to #261. GA4 event tracking updates.

### DIFF
--- a/src/AnnouncementsPage/announcements.json
+++ b/src/AnnouncementsPage/announcements.json
@@ -122,14 +122,14 @@
             {
                 "label": "Temporal dynamics of the multi-omic response to endurance exercise training across tissues",
                 "url": "https://www.biorxiv.org/content/10.1101/2022.09.21.508770v2",
-                "gaEventCategory": "MoTrPAC Landscape Preprint",
-                "gaEventAction": "bioRxiv"
+                "gaEventCategory": "MoTrPAC Landscape Paper",
+                "gaEventAction": "Preprint on bioRxiv"
             },
             {
                 "label": "R package consisting of the processed data and downstream analysis results presented in this preprint",
                 "url": "https://motrpac.github.io/MotrpacRatTraining6moData/",
-                "gaEventCategory": "MoTrPAC Landscape Preprint",
-                "gaEventAction": "MotrpacRatTraining6moData"
+                "gaEventCategory": "MoTrPAC Landscape Paper",
+                "gaEventAction": "MotrpacRatTraining6moData R package"
             }
         ]
     }

--- a/src/AnnouncementsPage/announcementsPage.jsx
+++ b/src/AnnouncementsPage/announcementsPage.jsx
@@ -68,9 +68,10 @@ function AnnouncementEntry({ entry }) {
                     rel="noopener noreferrer"
                     onClick={trackEvent.bind(
                       this,
+                      'User Interests',
                       link.gaEventCategory,
+                      'Announcement Page',
                       link.gaEventAction,
-                      'Announcement Page'
                     )}
                   >
                     {link.label}

--- a/src/BrowseDataPage/browseDataActions.js
+++ b/src/BrowseDataPage/browseDataActions.js
@@ -260,7 +260,12 @@ function handleDownloadRequest(email, name, selectedFiles) {
 
   // Track download request in Google Analytics
   const eventLabel = name + ' - ' + email;
-  trackEvent('Data file download', JSON.stringify(fileObjects), eventLabel);
+  trackEvent(
+    'Data Download',
+    'Selected Files',
+    eventLabel,
+    JSON.stringify(fileObjects),
+  );
 
   return (dispatch) => {
     dispatch(downloadRequested());

--- a/src/BrowseDataPage/components/bundleDownloadButton.jsx
+++ b/src/BrowseDataPage/components/bundleDownloadButton.jsx
@@ -49,7 +49,7 @@ function BundleDownloadButton({ bundlefile, profile }) {
       profile && profile.user_metadata
         ? `${profile.user_metadata.name} - ${profile.user_metadata.email}`
         : 'anonymous';
-    trackEvent('Bundle dataset download', file, eventLabel);
+    trackEvent('Data Download', 'Bundled Files', eventLabel, file);
     setTimeout(() => {
       setFetchStatus({
         status: null,

--- a/src/GoogleAnalytics/googleAnalytics.jsx
+++ b/src/GoogleAnalytics/googleAnalytics.jsx
@@ -43,10 +43,11 @@ export const withTracker = (WrappedComponent) => {
   return HOC;
 };
 
-export const trackEvent = (category, action, label) => {
+export const trackEvent = (category, action, label, target) => {
   gtag('event', action, {
     event_category: category,
     event_label: label,
+    event_target: target,
   });
 };
 

--- a/src/LandingPage/announcementBanner.jsx
+++ b/src/LandingPage/announcementBanner.jsx
@@ -14,9 +14,10 @@ function AnnouncementBanner() {
             rel="noopener noreferrer"
             onClick={trackEvent.bind(
               this,
-              'MoTrPAC Landscape Preprint',
-              'bioRxiv',
-              'Landing Page'
+              'User Interests',
+              'MoTrPAC Landscape Paper',
+              'Landing Page',
+              'Preprint on bioRxiv',
             )}
           >
             The MoTrPAC Endurance Exercise Training Animal Study Landscape
@@ -34,9 +35,10 @@ function AnnouncementBanner() {
             rel="noopener noreferrer"
             onClick={trackEvent.bind(
               this,
-              'MoTrPAC Landscape Preprint',
-              'MotrpacRatTraining6moData',
-              'Landing Page'
+              'User Interests',
+              'MoTrPAC Landscape Paper',
+              'Landing Page',
+              'MotrpacRatTraining6moData R package',
             )}
           >
             R package

--- a/src/LandingPage/promoteBanner.jsx
+++ b/src/LandingPage/promoteBanner.jsx
@@ -8,19 +8,20 @@ function PromoteBanner() {
       <h3 className="office-hour-title">Join Us</h3>
       <div className="office-hour-content mb-3">
         The Bioinformatics Center of MoTrPAC will be hosting the next virtual
-        Office Hour on Thursday, August 24, 2023 at 11:00 am Pacific Time.
+        Office Hour on Tuesday, September 26, 2023 at 11:00 am Pacific Time.
       </div>
       <a
-        href="https://docs.google.com/forms/d/e/1FAIpQLSfs-jT_lB0Z7naiV8pQkU8mLjadoejfPLQSstFfgDFg63AlIQ/viewform"
+        href="https://docs.google.com/forms/d/e/1FAIpQLSeY2lHGlbfLXhHT0aedNs98ORK4rc8FBhhXKE0nrW6vtSCqJA/viewform"
         className="btn btn-primary"
         role="button"
         target="_blank"
         rel="noopener noreferrer"
         onClick={trackEvent.bind(
           this,
-          'MoTrPAC Office Hour',
-          'August 24, 2023',
+          'User Engagement',
+          'Open Office Hour',
           'Landing Page',
+          'September 26, 2023',
         )}
       >
         SIGN UP

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -98,9 +98,14 @@ function ReleaseEntry({ profile, currentView }) {
           download
           onClick={trackEvent.bind(
             this,
-            `Release ${modalStatus.releaseVersion} Downloads (${currentView})`,
+            'Data Download',
+            `${currentView.toUpperCase()} Release ${
+              modalStatus.releaseVersion
+            }`,
+            profile && profile.user_metadata
+              ? `${profile.user_metadata.name} - ${profile.user_metadata.email}`
+              : 'anonymous',
             modalStatus.file,
-            profile.user_metadata.name
           )}
         >
           {modalStatus.message}

--- a/src/Search/searchPage.jsx
+++ b/src/Search/searchPage.jsx
@@ -542,9 +542,12 @@ function ResultsDownloadLink({ downloadPath, downloadError, profile }) {
           download
           onClick={trackEvent.bind(
             this,
-            'Search results download',
+            'Data Download',
+            'Search Results',
+            profile && profile.user_metadata
+              ? profile.user_metadata.name + ' - ' + profile.user_metadata.email
+              : 'anonymous',
             resultDownloadFilePath,
-            profile.user_metadata.name
           )}
         >
           Click this link to download the search results.

--- a/src/Search/searchPage.jsx
+++ b/src/Search/searchPage.jsx
@@ -545,7 +545,7 @@ function ResultsDownloadLink({ downloadPath, downloadError, profile }) {
             'Data Download',
             'Search Results',
             profile && profile.user_metadata
-              ? profile.user_metadata.name + ' - ' + profile.user_metadata.email
+              ? `${profile.user_metadata.name} - ${profile.user_metadata.email}`
               : 'anonymous',
             resultDownloadFilePath,
           )}


### PR DESCRIPTION
### Key Changes:

* Added event tracking parameter to GA4 to capture downloaded file list
* Updated event action values for various targeted events since GA4 only allows 40-characters max in this field
* Fixed JavaScript error causing **Search** page to crash due to missing `user_metadata` property in anonymous/unauthenticated users
* Udpated open office hour date info and sign-up form link