### PR TITLE
Connects to #263. GA4 Event Name value correctoion and Siteimprove Analytics addition.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,6 +54,9 @@
       })(window, document, "clarity", "script", "igkabpsgqm");
     </script>
 
+    <!-- Siteimprove Analytics -->
+    <script async src="https://siteimproveanalytics.com/js/siteanalyze_80352.js"></script>
+
     <title>MoTrPAC Data Hub</title>
   </head>
   <body>

--- a/src/AnnouncementsPage/announcementsPage.jsx
+++ b/src/AnnouncementsPage/announcementsPage.jsx
@@ -69,7 +69,7 @@ function AnnouncementEntry({ entry }) {
                     onClick={trackEvent.bind(
                       this,
                       'User Interests',
-                      link.gaEventCategory,
+                      link.gaEventCategory.toLowerCase().split(' ').join('_'),
                       'Announcement Page',
                       link.gaEventAction,
                     )}

--- a/src/Auth/authReducer.js
+++ b/src/Auth/authReducer.js
@@ -43,12 +43,19 @@ export function AuthReducer(state = defaultAuthState, action) {
         payload: {},
         profile: {},
       };
-    case PROFILE_RECEIVE:
+    case PROFILE_RECEIVE: {
+      const { profile } = action;
+      const { payload } = state;
+      const profileObj = { ...profile };
+      profileObj.userid =
+        payload && payload.idTokenPayload ? payload.idTokenPayload.sub : '';
+
       return {
         ...state,
         payload: {},
-        profile: action.profile,
+        profile: profileObj,
       };
+    }
     default:
       return state;
   }

--- a/src/BrowseDataPage/browseDataActions.js
+++ b/src/BrowseDataPage/browseDataActions.js
@@ -237,10 +237,13 @@ function handleUrlFetch(selectedFiles) {
 }
 
 // Request to download files
-function handleDownloadRequest(email, name, selectedFiles) {
+function handleDownloadRequest(email, name, selectedFiles, userid) {
   if (!email || !name || selectedFiles.length === 0) {
     return false;
   }
+
+  // Remove 'auth0|' substring from userid
+  const userID = userid ? userid.substring(userid.indexOf('|') + 1) : '';
 
   const fileObjects = [];
   selectedFiles.forEach((file) => {
@@ -254,16 +257,16 @@ function handleDownloadRequest(email, name, selectedFiles) {
 
   const requestBody = {
     email,
-    name,
+    name: `${name} (${userID})`,
     files: fileObjects,
   };
 
   // Track download request in Google Analytics
-  const eventLabel = name + ' - ' + email;
+  // No longer capture full names and email addresses
   trackEvent(
     'Data Download',
-    'Selected Files',
-    eventLabel,
+    'selected_files',
+    userID,
     JSON.stringify(fileObjects),
   );
 

--- a/src/BrowseDataPage/browseDataPage.jsx
+++ b/src/BrowseDataPage/browseDataPage.jsx
@@ -93,6 +93,7 @@ BrowseDataPage.propTypes = {
       userType: PropTypes.string,
       email: PropTypes.string,
       name: PropTypes.string,
+      userid: PropTypes.string,
     }),
   }),
   activeFilters: BrowseDataFilter.propTypes.activeFilters.isRequired,
@@ -120,8 +121,8 @@ const mapDispatchToProps = (dispatch) => ({
   changePageRequest: (maxRows, page) =>
     dispatch(actions.changePageRequest(maxRows, page)),
   loadDataObjects: (files) => dispatch(actions.loadDataObjects(files)),
-  handleDownloadRequest: (email, name, selectedFiles) =>
-    dispatch(actions.handleDownloadRequest(email, name, selectedFiles)),
+  handleDownloadRequest: (email, name, selectedFiles, userid) =>
+    dispatch(actions.handleDownloadRequest(email, name, selectedFiles, userid)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(BrowseDataPage);

--- a/src/BrowseDataPage/browseDataTable.jsx
+++ b/src/BrowseDataPage/browseDataTable.jsx
@@ -165,7 +165,8 @@ function DataTable({
       handleDownloadRequest(
         profile.user_metadata.email,
         profile.user_metadata.name,
-        selectedFiles
+        profile.userid,
+        selectedFiles,
       );
     }
   }
@@ -279,6 +280,7 @@ BrowseDataTable.propTypes = {
   handleDownloadRequest: PropTypes.func.isRequired,
   downloadRequestResponse: PropTypes.string.isRequired,
   profile: PropTypes.shape({
+    userid: PropTypes.string,
     user_metadata: PropTypes.shape({
       userType: PropTypes.string,
       email: PropTypes.string,
@@ -304,6 +306,7 @@ DataTable.propTypes = {
   handleDownloadRequest: PropTypes.func.isRequired,
   downloadRequestResponse: PropTypes.string.isRequired,
   profile: PropTypes.shape({
+    userid: PropTypes.string,
     user_metadata: PropTypes.shape({
       userType: PropTypes.string,
       email: PropTypes.string,

--- a/src/BrowseDataPage/components/bundleDownloadButton.jsx
+++ b/src/BrowseDataPage/components/bundleDownloadButton.jsx
@@ -45,11 +45,11 @@ function BundleDownloadButton({ bundlefile, profile }) {
 
   // reset state upon user clicking download link
   function handleFileDownload(file) {
-    const eventLabel =
-      profile && profile.user_metadata
-        ? `${profile.user_metadata.name} - ${profile.user_metadata.email}`
+    const userID =
+      profile && profile.userid
+        ? profile.userid.substring(profile.userid.indexOf('|') + 1)
         : 'anonymous';
-    trackEvent('Data Download', 'Bundled Files', eventLabel, file);
+    trackEvent('Data Download', 'bundled_files', userID, file);
     setTimeout(() => {
       setFetchStatus({
         status: null,
@@ -154,6 +154,7 @@ function BundleDownloadButton({ bundlefile, profile }) {
 BundleDownloadButton.propTypes = {
   bundlefile: PropTypes.string.isRequired,
   profile: PropTypes.shape({
+    userid: PropTypes.string,
     user_metadata: PropTypes.shape({
       userType: PropTypes.string,
       email: PropTypes.string,

--- a/src/LandingPage/announcementBanner.jsx
+++ b/src/LandingPage/announcementBanner.jsx
@@ -15,7 +15,7 @@ function AnnouncementBanner() {
             onClick={trackEvent.bind(
               this,
               'User Interests',
-              'MoTrPAC Landscape Paper',
+              'motrpac_landscape_paper',
               'Landing Page',
               'Preprint on bioRxiv',
             )}
@@ -36,7 +36,7 @@ function AnnouncementBanner() {
             onClick={trackEvent.bind(
               this,
               'User Interests',
-              'MoTrPAC Landscape Paper',
+              'motrpac_landscape_paper',
               'Landing Page',
               'MotrpacRatTraining6moData R package',
             )}

--- a/src/LandingPage/landingPage.jsx
+++ b/src/LandingPage/landingPage.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { Redirect, Link } from 'react-router-dom';
 import Particles from 'react-particles-js';
 import { Helmet } from 'react-helmet';
-import { trackEvent } from '../GoogleAnalytics/googleAnalytics';
 import LogoAnimation from '../assets/LandingPageGraphics/LogoAnimation_03082019-yellow_pipelineball_left.gif';
 import LayerRunner from '../assets/LandingPageGraphics/Data_Layer_Runner.png';
 import HealthyHeart from '../assets/LandingPageGraphics/Infographic_Healthy_Heart.png';

--- a/src/LandingPage/promoteBanner.jsx
+++ b/src/LandingPage/promoteBanner.jsx
@@ -19,7 +19,7 @@ function PromoteBanner() {
         onClick={trackEvent.bind(
           this,
           'User Engagement',
-          'Open Office Hour',
+          'open_office_hour',
           'Landing Page',
           'September 26, 2023',
         )}

--- a/src/ReleasePage/releaseEntry.jsx
+++ b/src/ReleasePage/releaseEntry.jsx
@@ -99,11 +99,9 @@ function ReleaseEntry({ profile, currentView }) {
           onClick={trackEvent.bind(
             this,
             'Data Download',
-            `${currentView.toUpperCase()} Release ${
-              modalStatus.releaseVersion
-            }`,
-            profile && profile.user_metadata
-              ? `${profile.user_metadata.name} - ${profile.user_metadata.email}`
+            `${currentView}_release_${modalStatus.releaseVersion}`,
+            profile && profile.userid
+              ? profile.userid.substring(profile.userid.indexOf('|') + 1)
               : 'anonymous',
             modalStatus.file,
           )}
@@ -398,6 +396,8 @@ function ReleaseEntry({ profile, currentView }) {
 ReleaseEntry.propTypes = {
   profile: PropTypes.shape({
     name: PropTypes.string,
+    email: PropTypes.string,
+    userid: PropTypes.string,
     user_metadata: PropTypes.object,
   }).isRequired,
   currentView: PropTypes.string.isRequired,

--- a/src/ReleasePage/releasePage.jsx
+++ b/src/ReleasePage/releasePage.jsx
@@ -99,6 +99,8 @@ export function ReleasePage({ profile }) {
 ReleasePage.propTypes = {
   profile: PropTypes.shape({
     name: PropTypes.string,
+    email: PropTypes.string,
+    userid: PropTypes.string,
     user_metadata: PropTypes.object,
   }).isRequired,
 };

--- a/src/Search/searchPage.jsx
+++ b/src/Search/searchPage.jsx
@@ -543,9 +543,9 @@ function ResultsDownloadLink({ downloadPath, downloadError, profile }) {
           onClick={trackEvent.bind(
             this,
             'Data Download',
-            'Search Results',
-            profile && profile.user_metadata
-              ? `${profile.user_metadata.name} - ${profile.user_metadata.email}`
+            'search_results',
+            profile && profile.userid
+              ? profile.userid.substring(profile.userid.indexOf('|') + 1)
               : 'anonymous',
             resultDownloadFilePath,
           )}
@@ -617,6 +617,7 @@ function ResultsDownloadModal({
 
 SearchPage.propTypes = {
   profile: PropTypes.shape({
+    userid: PropTypes.string,
     user_metadata: PropTypes.object,
   }),
   searchResults: PropTypes.shape({

--- a/src/testData/testUser.json
+++ b/src/testData/testUser.json
@@ -9,5 +9,6 @@
     "siteName": "Stanford",
     "hasAccess": true,
     "userType": "internal"
-  }
+  },
+  "userid": ""
 }


### PR DESCRIPTION
### Key Changes:

* Added Siteimprove Analytics script to `index.html` header to track site usage through [Stanford's Siteimprove service](https://my2.siteimprove.com/).
* Updated GA4 event tracking implementation to replace name/email values with `userid`s pertinent to data access/download events.