### PR TITLE
Connects to #265. Homepage redesign UI enhancement.

### DIFF
--- a/src/LandingPage/components/figure1c.jsx
+++ b/src/LandingPage/components/figure1c.jsx
@@ -1,0 +1,349 @@
+import React, { useRef } from 'react';
+import * as d3 from 'd3';
+
+const dataset = require('./figure1c_data.json');
+
+const figureTissueProps = require('./figureTissueProps.json');
+
+const tissueLabels = [
+  'BLOOD',
+  'PLASMA',
+  'HEART',
+  'VENACV',
+  'SPLEEN',
+  'SKM-GN',
+  'SKM-VL',
+  'WAT-SC',
+  'BAT',
+  'LIVER',
+  'LUNG',
+  'KIDNEY',
+  'ADRNL',
+  'CORTEX',
+  'HYPOTH',
+  'HIPPOC',
+  'SMLINT',
+  'COLON',
+  'OVARY',
+  'TESTES',
+];
+
+const omeLabels = [
+  'METAB',
+  'IMMUNO',
+  'UBIQ',
+  'ACETYL',
+  'PHOSPHO',
+  'PROT',
+  'TRNSCRPT',
+  'ATAC',
+  'METHYL',
+];
+
+const omeColors = [
+  { type: 'Genomics', color: '#FC8D62' },
+  { type: 'Proteomics', color: '#8DA0CB' },
+  { type: 'Metabolomics', color: '#66C2A5' },
+  { type: 'Immunoassays', color: '#E78AC3' },
+];
+
+/**
+ * Renders landscape paper figure 1c heatmap
+ *
+ * @returns {Object} JSX representation of figure 1c heatmap
+ */
+function Figure1C() {
+  const svgRef = useRef();
+
+  function renderHeatmap() {
+    // set the dimensions and margins of the graph
+    const margin = { top: 0, right: 20, bottom: 100, left: 130 };
+    // calc width by number of pass1b-06 tissues (20) vs each square's pixel width
+    const width = 20 * 55;
+    // calc height by number of omes vs each sqaure's pixel height
+    const height = 9 * 55;
+
+    // select DOM element to draw graph
+    const div = d3.select(svgRef.current);
+    div.selectAll('*').remove();
+
+    // append the svg object to the selected DOM element
+    // append a 'group' element to 'svg'
+    // moves the 'group' element to the top left margin
+    const svg = div
+      .append('svg')
+      .attr('width', width + margin.left + margin.right)
+      .attr('height', height + margin.top + margin.bottom)
+      .attr('class', 'heatmap-svg')
+      .append('g')
+      .attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+    // build X scales and axis
+    const x = d3
+      .scaleBand()
+      .range([0, width])
+      .domain(tissueLabels)
+      .padding(0.1);
+
+    // draw X axis
+    svg
+      .append('g')
+      .attr('transform', 'translate(0,' + height + ')')
+      .call(d3.axisBottom(x).tickSize(0).tickPadding(0))
+      .selectAll('text')
+      .attr('transform', 'translate(-10, 8)rotate(-90)')
+      .style('text-anchor', 'end')
+      .style('color', '#ffffff')
+      .style('font-size', '20px')
+      .style('font-weight', '500')
+      .select('.domain')
+      .remove();
+
+    // Remove X axis line
+    svg.call(d3.axisBottom(x).tickSize(0)).select('.domain').remove();
+
+    // build Y scales and axis
+    const y = d3.scaleBand().range([height, 0]).domain(omeLabels).padding(0.1);
+
+    // draw Y axis
+    svg
+      .append('g')
+      .attr('class', 'heatmap-y-axis')
+      .call(d3.axisLeft(y).tickSize(0).tickPadding(6))
+      .style('color', '#ffffff')
+      .style('font-size', '20px')
+      .style('font-weight', '500')
+      .select('.domain')
+      .remove();
+
+    // build color scale
+    const colorScale = d3
+      .scaleSequential()
+      .interpolator(d3.interpolateViridis)
+      .domain([0, 0.1]);
+
+    // create a tooltip
+    const tooltip = d3
+      .select('body')
+      .append('div')
+      .style('opacity', 0)
+      .attr('class', 'heatmap-tooltip');
+
+    // Tooltip functions
+    const onMouseOver = (event) => {
+      d3.select(event.currentTarget).attr('rx', 12).attr('ry', 12);
+    };
+    const onMouseMove = (event, d) => {
+      tooltip
+        .html(
+          'Tissue: ' +
+            figureTissueProps[d.tissue].label +
+            '<br/>Assay: ' +
+            d.ome,
+        )
+        .style('top', event.pageY - 60 + 'px')
+        .style('left', event.pageX + 'px');
+      tooltip.transition().duration(100).style('opacity', 1);
+      d3.select(this).style('opacity', 1);
+    };
+    const onMouseLeave = (event) => {
+      tooltip.transition().duration(100).style('opacity', 0);
+      d3.select(event.currentTarget).attr('rx', 4).attr('ry', 4);
+    };
+
+    // Draw squares
+    const rect = svg
+      .selectAll()
+      .data(dataset, (d) => d.tissue + ':' + d.ome)
+      .enter();
+
+    rect
+      .append('rect')
+      .attr('x', (d) => x(d.tissue))
+      .attr('y', (d) => y(d.ome))
+      .attr('rx', 4)
+      .attr('ry', 4)
+      .attr('width', x.bandwidth())
+      .attr('height', y.bandwidth())
+      .style('fill', (d) =>
+        d.featureCnt !== null ? colorScale(d.diffProportion) : '#ffffff',
+      )
+      .style('stroke-width', 0)
+      .style('stroke', 'none')
+      .on('mouseover', onMouseOver)
+      .on('mousemove', onMouseMove)
+      .on('mouseleave', onMouseLeave);
+
+    // Draw text inside squares
+    rect
+      .append('text')
+      .attr('x', (d) => x(d.tissue) + 24) // Center text horizontally
+      .attr('y', (d) => y(d.ome) + 30) // Center text vertically
+      .attr('text-anchor', 'middle') // Center text horizontally
+      .attr('alignment-baseline', 'middle') // Center text vertically
+      .style('fill', (d) => (d.diffProportion > 0.04 ? '#000000' : '#ffffff'))
+      .style('font-size', '16px')
+      .style('cursor', 'default')
+      .text((d) => d.featureCnt);
+
+    // Heatmap legend with continuous gradient
+    const legendMargin = { top: 15, bottom: 15, left: 20, right: 20 };
+    const legendWidth = 120;
+    const legendHeight = 580; // Same as heatmap height
+    const legendColorScaleHeight = 340;
+
+    // Append the svg legend to the body of the page
+    const legend = div
+      .append('svg')
+      .attr('width', legendWidth + legendMargin.left + legendMargin.right)
+      .attr('height', legendHeight + legendMargin.top + legendMargin.bottom);
+
+    // legend color scale
+    const legendColorScale = d3
+      .scaleSequential(d3.interpolateViridis)
+      .domain([0.1, 0]);
+
+    // build legend Y scales and axis:
+    const legendYAxisScale = d3
+      .scaleLinear()
+      .range([legendMargin.top + 260, legendHeight + 2])
+      .domain(legendColorScale.domain());
+
+    const legendYAxisRight = (g) =>
+      g
+        .attr('class', 'legend-y-axis')
+        .attr(
+          'tranform',
+          `translate(${legendMargin.left + legendWidth}, ${legendMargin.top})`,
+        )
+        .call(
+          d3
+            .axisRight(legendYAxisScale)
+            .ticks(5)
+            .tickSize(0)
+            .tickPadding(40)
+            .tickFormat((i) => {
+              if (i === 0.1) {
+                return '0.1+';
+              }
+              return i;
+            }),
+        );
+
+    const defs = legend.append('defs');
+    // create gradient color scale in legend
+    // and reverse its vertical orientation
+    const linearGradient = defs
+      .append('linearGradient')
+      .attr('id', 'heatmapGradient')
+      .attr('x1', '0%') // bottom
+      .attr('y1', '100%')
+      .attr('x2', '0%') // to top
+      .attr('y2', '0%');
+
+    // append multiple color stops by using D3's data/enter step
+    linearGradient
+      .selectAll('stop')
+      .data(
+        legendColorScale.ticks().map((t, i, n) => ({
+          offset: `${(100 * i) / n.length}%`,
+          color: legendColorScale(t),
+        })),
+      )
+      .enter()
+      .append('stop')
+      .attr('offset', (d) => d.offset)
+      .attr('stop-color', (d) => d.color);
+
+    // draw the rectangle and fill with gradient color scale
+    legend
+      .append('g')
+      .attr('transform', `translate(0, ${legendMargin.top})`)
+      .append('rect')
+      .attr('transform', `translate(0, 260)`)
+      .attr('width', 30)
+      .attr('rx', 4)
+      .attr('ry', 4)
+      .attr(
+        'height',
+        legendColorScaleHeight - legendMargin.top - legendMargin.bottom,
+      )
+      .style('fill', 'url(#heatmapGradient)');
+
+    // legend.selectAll('#heatmapGradient').attr('gradientTransform', 'rotate(0)');
+
+    // remove Y axis line
+    legend.append('g').call(legendYAxisRight).select('.domain').remove();
+
+    // draw legend title/label
+    legend
+      .append('text')
+      .attr('class', 'legend-title-diff-proportion')
+      .attr('x', 0)
+      .attr('y', legendMargin.top + 200)
+      .append('tspan')
+      .text('Differential')
+      .append('tspan')
+      .attr('x', 0)
+      .attr('y', legendMargin.top + 220)
+      .text('proportion')
+      .append('tspan')
+      .text('of analytes')
+      .attr('x', 0)
+      .attr('y', legendMargin.top + 240);
+
+    // draw ome type legend title/label
+    legend
+      .append('text')
+      .attr('class', 'legend-title-ome-type')
+      .attr('x', 0)
+      .attr('y', legendMargin.top + 10)
+      .append('tspan')
+      .text('Ome Type');
+
+    // draw ome type legend
+    const legendOmeType = legend
+      .append('g')
+      .attr('class', 'legend-ome-type')
+      .attr('transform', `translate(0, ${legendMargin.top})`)
+      .selectAll('g')
+      .data(omeColors)
+      .enter()
+      .append('g')
+      .attr(
+        'transform',
+        (d, i) => `translate(0, ${legendMargin.top + 10 + i * 36})`,
+      );
+
+    legendOmeType
+      .append('rect')
+      .attr('width', 30)
+      .attr('height', 30)
+      .attr('x', 0)
+      .attr('y', 0)
+      .attr('rx', 4)
+      .attr('ry', 4)
+      .style('fill', (d) => d.color);
+
+    legendOmeType
+      .append('text')
+      .attr('x', 40)
+      .attr('y', 20)
+      .text((d) => d.type)
+      .style('font-size', '16px')
+      .style('font-weight', '400')
+      .style('fill', '#ffffff');
+  }
+
+  return (
+    <div
+      ref={svgRef}
+      id="heatmap-container"
+      className="d-flex align-items-center justify-content-center position-relative"
+    >
+      {renderHeatmap()}
+    </div>
+  );
+}
+
+export default Figure1C;

--- a/src/LandingPage/components/figure1c.jsx
+++ b/src/LandingPage/components/figure1c.jsx
@@ -40,6 +40,18 @@ const omeLabels = [
   'METHYL',
 ];
 
+const assayMap = {
+  METAB: 'Metabolomics',
+  IMMUNO: 'Immunoassays',
+  UBIQ: 'Ubiquitylome',
+  ACETYL: 'Acetylproteomics',
+  PHOSPHO: 'Phosphoproteomics',
+  PROT: 'Global proteomics',
+  TRNSCRPT: 'RNA-Seq',
+  ATAC: 'ATAC-seq',
+  METHYL: 'RRBS',
+};
+
 const omeColors = [
   { type: 'Genomics', color: '#FC8D62' },
   { type: 'Proteomics', color: '#8DA0CB' },
@@ -130,25 +142,31 @@ function Figure1C() {
       .attr('class', 'heatmap-tooltip');
 
     // Tooltip functions
-    const onMouseOver = (event) => {
-      d3.select(event.currentTarget).attr('rx', 12).attr('ry', 12);
+    const onMouseOver = (event, d) => {
+      if (d.featureCnt !== null) {
+        d3.select(event.currentTarget).attr('rx', 12).attr('ry', 12);
+      }
     };
     const onMouseMove = (event, d) => {
-      tooltip
-        .html(
-          'Tissue: ' +
-            figureTissueProps[d.tissue].label +
-            '<br/>Assay: ' +
-            d.ome,
-        )
-        .style('top', event.pageY - 60 + 'px')
-        .style('left', event.pageX + 'px');
-      tooltip.transition().duration(100).style('opacity', 1);
-      d3.select(this).style('opacity', 1);
+      if (d.featureCnt !== null) {
+        tooltip
+          .html(
+            'Tissue: ' +
+              figureTissueProps[d.tissue].label +
+              '<br/>Assay: ' +
+              assayMap[d.ome],
+          )
+          .style('top', event.pageY - 60 + 'px')
+          .style('left', event.pageX + 'px');
+        tooltip.transition().duration(100).style('opacity', 1);
+        d3.select(this).style('opacity', 1);
+      }
     };
-    const onMouseLeave = (event) => {
-      tooltip.transition().duration(100).style('opacity', 0);
-      d3.select(event.currentTarget).attr('rx', 4).attr('ry', 4);
+    const onMouseLeave = (event, d) => {
+      if (d.featureCnt !== null) {
+        tooltip.transition().duration(100).style('opacity', 0);
+        d3.select(event.currentTarget).attr('rx', 4).attr('ry', 4);
+      }
     };
 
     // Draw squares

--- a/src/LandingPage/components/figure1c_data.json
+++ b/src/LandingPage/components/figure1c_data.json
@@ -1,0 +1,1622 @@
+[
+  {
+    "ome": "METHYL",
+    "tissue": "BLOOD",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#DDA0DD"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "BLOOD",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#DDA0DD"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "BLOOD",
+    "omeType": "Genomics",
+    "featureCnt": 1582,
+    "diffProportion": 0.1,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#DDA0DD"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "BLOOD",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#DDA0DD"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "BLOOD",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#DDA0DD"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "BLOOD",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#DDA0DD"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "BLOOD",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#DDA0DD"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "BLOOD",
+    "omeType": "Immunoassays",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#DDA0DD"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "BLOOD",
+    "omeType": "Metabolomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#DDA0DD"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "PLASMA",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#8c5220"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "PLASMA",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#8c5220"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "PLASMA",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#8c5220"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "PLASMA",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#8c5220"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "PLASMA",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#8c5220"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "PLASMA",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#8c5220"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "PLASMA",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#8c5220"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "PLASMA",
+    "omeType": "Immunoassays",
+    "featureCnt": 14,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#8c5220"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "PLASMA",
+    "omeType": "Metabolomics",
+    "featureCnt": 529,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#8c5220"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "HEART",
+    "omeType": "Genomics",
+    "featureCnt": 107,
+    "diffProportion": 0.0001094885656076,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#d92c04"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "HEART",
+    "omeType": "Genomics",
+    "featureCnt": 75,
+    "diffProportion": 0.0001029758652032,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#d92c04"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "HEART",
+    "omeType": "Genomics",
+    "featureCnt": 722,
+    "diffProportion": 0.0499826929733472,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#d92c04"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "HEART",
+    "omeType": "Proteomics",
+    "featureCnt": 693,
+    "diffProportion": 0.0754573170731707,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#d92c04"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "HEART",
+    "omeType": "Proteomics",
+    "featureCnt": 436,
+    "diffProportion": 0.0108436132113012,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#d92c04"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "HEART",
+    "omeType": "Proteomics",
+    "featureCnt": 450,
+    "diffProportion": 0.0863226549012085,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#d92c04"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "HEART",
+    "omeType": "Proteomics",
+    "featureCnt": 24,
+    "diffProportion": 0.0033907883582933,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#d92c04"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "HEART",
+    "omeType": "Immunoassays",
+    "featureCnt": 4,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#d92c04"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "HEART",
+    "omeType": "Metabolomics",
+    "featureCnt": 568,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#d92c04"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "VENACV",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#5a2e15"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "VENACV",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#5a2e15"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "VENACV",
+    "omeType": "Genomics",
+    "featureCnt": 90,
+    "diffProportion": 0.0055086301872934,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#5a2e15"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "VENACV",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#5a2e15"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "VENACV",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#5a2e15"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "VENACV",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#5a2e15"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "VENACV",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#5a2e15"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "VENACV",
+    "omeType": "Immunoassays",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#5a2e15"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "VENACV",
+    "omeType": "Metabolomics",
+    "featureCnt": 23,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#5a2e15"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "SPLEEN",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f2e751"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "SPLEEN",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f2e751"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "SPLEEN",
+    "omeType": "Genomics",
+    "featureCnt": 1099,
+    "diffProportion": 0.0673448127949016,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f2e751"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "SPLEEN",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f2e751"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "SPLEEN",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f2e751"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "SPLEEN",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f2e751"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "SPLEEN",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f2e751"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "SPLEEN",
+    "omeType": "Immunoassays",
+    "featureCnt": 12,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#f2e751"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "SPLEEN",
+    "omeType": "Metabolomics",
+    "featureCnt": 83,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#f2e751"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "SKM-GN",
+    "omeType": "Genomics",
+    "featureCnt": 119,
+    "diffProportion": 0.0001077944441475,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f28b2f"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "SKM-GN",
+    "omeType": "Genomics",
+    "featureCnt": 442,
+    "diffProportion": 0.0004507890337918,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f28b2f"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "SKM-GN",
+    "omeType": "Genomics",
+    "featureCnt": 566,
+    "diffProportion": 0.0410919122985335,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f28b2f"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "SKM-GN",
+    "omeType": "Proteomics",
+    "featureCnt": 691,
+    "diffProportion": 0.1,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f28b2f"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "SKM-GN",
+    "omeType": "Proteomics",
+    "featureCnt": 694,
+    "diffProportion": 0.0234056186975144,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f28b2f"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "SKM-GN",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f28b2f"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "SKM-GN",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f28b2f"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "SKM-GN",
+    "omeType": "Immunoassays",
+    "featureCnt": 7,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#f28b2f"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "SKM-GN",
+    "omeType": "Metabolomics",
+    "featureCnt": 298,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#f28b2f"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "SKM-VL",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#bf7534"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "SKM-VL",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#bf7534"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "SKM-VL",
+    "omeType": "Genomics",
+    "featureCnt": 766,
+    "diffProportion": 0.054820010019323,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#bf7534"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "SKM-VL",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#bf7534"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "SKM-VL",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#bf7534"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "SKM-VL",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#bf7534"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "SKM-VL",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#bf7534"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "SKM-VL",
+    "omeType": "Immunoassays",
+    "featureCnt": 10,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#bf7534"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "SKM-VL",
+    "omeType": "Metabolomics",
+    "featureCnt": 53,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#bf7534"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "WAT-SC",
+    "omeType": "Genomics",
+    "featureCnt": 328,
+    "diffProportion": 0.0003799590153964,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f2b443"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "WAT-SC",
+    "omeType": "Genomics",
+    "featureCnt": 4,
+    "diffProportion": 0.00000361928718138963,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f2b443"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "WAT-SC",
+    "omeType": "Genomics",
+    "featureCnt": 1742,
+    "diffProportion": 0.1,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f2b443"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "WAT-SC",
+    "omeType": "Proteomics",
+    "featureCnt": 649,
+    "diffProportion": 0.0651344841429145,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f2b443"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "WAT-SC",
+    "omeType": "Proteomics",
+    "featureCnt": 50,
+    "diffProportion": 0.0016499472016895,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f2b443"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "WAT-SC",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f2b443"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "WAT-SC",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f2b443"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "WAT-SC",
+    "omeType": "Immunoassays",
+    "featureCnt": 12,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#f2b443"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "WAT-SC",
+    "omeType": "Metabolomics",
+    "featureCnt": 330,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#f2b443"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "BAT",
+    "omeType": "Genomics",
+    "featureCnt": 621,
+    "diffProportion": 0.00056403064839,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#7553a7"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "BAT",
+    "omeType": "Genomics",
+    "featureCnt": 253,
+    "diffProportion": 0.0002490772818875,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#7553a7"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "BAT",
+    "omeType": "Genomics",
+    "featureCnt": 1635,
+    "diffProportion": 0.1,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#7553a7"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "BAT",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#7553a7"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "BAT",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#7553a7"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "BAT",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#7553a7"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "BAT",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#7553a7"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "BAT",
+    "omeType": "Immunoassays",
+    "featureCnt": 11,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#7553a7"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "BAT",
+    "omeType": "Metabolomics",
+    "featureCnt": 254,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#7553a7"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "LIVER",
+    "omeType": "Genomics",
+    "featureCnt": 103,
+    "diffProportion": 0.0001189975553511,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#da6c75"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "LIVER",
+    "omeType": "Genomics",
+    "featureCnt": 1032,
+    "diffProportion": 0.0017137220648358,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#da6c75"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "LIVER",
+    "omeType": "Genomics",
+    "featureCnt": 276,
+    "diffProportion": 0.0191175451963704,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#da6c75"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "LIVER",
+    "omeType": "Proteomics",
+    "featureCnt": 1042,
+    "diffProportion": 0.1,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#da6c75"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "LIVER",
+    "omeType": "Proteomics",
+    "featureCnt": 720,
+    "diffProportion": 0.0165262698831685,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#da6c75"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "LIVER",
+    "omeType": "Proteomics",
+    "featureCnt": 2012,
+    "diffProportion": 0.1,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#da6c75"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "LIVER",
+    "omeType": "Proteomics",
+    "featureCnt": 161,
+    "diffProportion": 0.0172303082191781,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#da6c75"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "LIVER",
+    "omeType": "Immunoassays",
+    "featureCnt": 7,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#da6c75"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "LIVER",
+    "omeType": "Metabolomics",
+    "featureCnt": 598,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#da6c75"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "LUNG",
+    "omeType": "Genomics",
+    "featureCnt": 109,
+    "diffProportion": 0.0000804072590788279,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#04bf8a"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "LUNG",
+    "omeType": "Genomics",
+    "featureCnt": 173,
+    "diffProportion": 0.0002176412718301,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#04bf8a"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "LUNG",
+    "omeType": "Genomics",
+    "featureCnt": 961,
+    "diffProportion": 0.058224780369585,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#04bf8a"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "LUNG",
+    "omeType": "Proteomics",
+    "featureCnt": 318,
+    "diffProportion": 0.0292360025742392,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#04bf8a"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "LUNG",
+    "omeType": "Proteomics",
+    "featureCnt": 272,
+    "diffProportion": 0.0057069721575292,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#04bf8a"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "LUNG",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#04bf8a"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "LUNG",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#04bf8a"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "LUNG",
+    "omeType": "Immunoassays",
+    "featureCnt": 9,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#04bf8a"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "LUNG",
+    "omeType": "Metabolomics",
+    "featureCnt": 301,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#04bf8a"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "KIDNEY",
+    "omeType": "Genomics",
+    "featureCnt": 82,
+    "diffProportion": 0.0001499011931769,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f2ced0"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "KIDNEY",
+    "omeType": "Genomics",
+    "featureCnt": 237,
+    "diffProportion": 0.000283444678057,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f2ced0"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "KIDNEY",
+    "omeType": "Genomics",
+    "featureCnt": 339,
+    "diffProportion": 0.0212126900694575,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f2ced0"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "KIDNEY",
+    "omeType": "Proteomics",
+    "featureCnt": 247,
+    "diffProportion": 0.0250710515631344,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f2ced0"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "KIDNEY",
+    "omeType": "Proteomics",
+    "featureCnt": 19,
+    "diffProportion": 0.0006303078556263,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f2ced0"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "KIDNEY",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f2ced0"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "KIDNEY",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f2ced0"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "KIDNEY",
+    "omeType": "Immunoassays",
+    "featureCnt": 3,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#f2ced0"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "KIDNEY",
+    "omeType": "Metabolomics",
+    "featureCnt": 220,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#f2ced0"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "ADRNL",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f1997c"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "ADRNL",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f1997c"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "ADRNL",
+    "omeType": "Genomics",
+    "featureCnt": 4493,
+    "diffProportion": 0.1,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f1997c"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "ADRNL",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f1997c"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "ADRNL",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f1997c"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "ADRNL",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f1997c"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "ADRNL",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f1997c"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "ADRNL",
+    "omeType": "Immunoassays",
+    "featureCnt": 22,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#f1997c"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "ADRNL",
+    "omeType": "Metabolomics",
+    "featureCnt": 89,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#f1997c"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "CORTEX",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#088c03"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "CORTEX",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#088c03"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "CORTEX",
+    "omeType": "Genomics",
+    "featureCnt": 105,
+    "diffProportion": 0.0063856960408684,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#088c03"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "CORTEX",
+    "omeType": "Proteomics",
+    "featureCnt": 14,
+    "diffProportion": 0.0012603528988116,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#088c03"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "CORTEX",
+    "omeType": "Proteomics",
+    "featureCnt": 389,
+    "diffProportion": 0.0083652316029418,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#088c03"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "CORTEX",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#088c03"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "CORTEX",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#088c03"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "CORTEX",
+    "omeType": "Immunoassays",
+    "featureCnt": 10,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#088c03"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "CORTEX",
+    "omeType": "Metabolomics",
+    "featureCnt": 44,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#088c03"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "HYPOTH",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#025939"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "HYPOTH",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#025939"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "HYPOTH",
+    "omeType": "Genomics",
+    "featureCnt": 16,
+    "diffProportion": 0.0009436744323208,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#025939"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "HYPOTH",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#025939"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "HYPOTH",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#025939"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "HYPOTH",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#025939"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "HYPOTH",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#025939"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "HYPOTH",
+    "omeType": "Immunoassays",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#025939"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "HYPOTH",
+    "omeType": "Metabolomics",
+    "featureCnt": 46,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#025939"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "HIPPOC",
+    "omeType": "Genomics",
+    "featureCnt": 61,
+    "diffProportion": 0.0000790762852813106,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f3c288"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "HIPPOC",
+    "omeType": "Genomics",
+    "featureCnt": 31,
+    "diffProportion": 0.0000451614595018254,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f3c288"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "HIPPOC",
+    "omeType": "Genomics",
+    "featureCnt": 244,
+    "diffProportion": 0.0146917148362235,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#f3c288"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "HIPPOC",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f3c288"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "HIPPOC",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f3c288"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "HIPPOC",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f3c288"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "HIPPOC",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#f3c288"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "HIPPOC",
+    "omeType": "Immunoassays",
+    "featureCnt": 9,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#f3c288"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "HIPPOC",
+    "omeType": "Metabolomics",
+    "featureCnt": 146,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#f3c288"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "SMLINT",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#A18277"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "SMLINT",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#A18277"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "SMLINT",
+    "omeType": "Genomics",
+    "featureCnt": 746,
+    "diffProportion": 0.0410919122985335,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#A18277"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "SMLINT",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#A18277"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "SMLINT",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#A18277"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "SMLINT",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#A18277"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "SMLINT",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#A18277"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "SMLINT",
+    "omeType": "Immunoassays",
+    "featureCnt": 5,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#A18277"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "SMLINT",
+    "omeType": "Metabolomics",
+    "featureCnt": 36,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#A18277"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "COLON",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#6d86a5"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "COLON",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#6d86a5"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "COLON",
+    "omeType": "Genomics",
+    "featureCnt": 2516,
+    "diffProportion": 0.1,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#6d86a5"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "COLON",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#6d86a5"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "COLON",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#6d86a5"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "COLON",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#6d86a5"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "COLON",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#6d86a5"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "COLON",
+    "omeType": "Immunoassays",
+    "featureCnt": 6,
+    "diffProportion": 0.1,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#6d86a5"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "COLON",
+    "omeType": "Metabolomics",
+    "featureCnt": 52,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#6d86a5"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "OVARY",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#a5415b"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "OVARY",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#a5415b"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "OVARY",
+    "omeType": "Genomics",
+    "featureCnt": 896,
+    "diffProportion": 0.0525975931904902,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#a5415b"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "OVARY",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#a5415b"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "OVARY",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#a5415b"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "OVARY",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#a5415b"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "OVARY",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#a5415b"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "OVARY",
+    "omeType": "Immunoassays",
+    "featureCnt": 0,
+    "diffProportion": 0,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#a5415b"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "OVARY",
+    "omeType": "Metabolomics",
+    "featureCnt": 21,
+    "diffProportion": 0.0921052631578947,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#a5415b"
+  },
+  {
+    "ome": "METHYL",
+    "tissue": "TESTES",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#214da6"
+  },
+  {
+    "ome": "ATAC",
+    "tissue": "TESTES",
+    "omeType": "Genomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#214da6"
+  },
+  {
+    "ome": "TRNSCRPT",
+    "tissue": "TESTES",
+    "omeType": "Genomics",
+    "featureCnt": 107,
+    "diffProportion": 0.0061639495362636,
+    "omeColor": "#FC8D62",
+    "tissueColor": "#214da6"
+  },
+  {
+    "ome": "PROT",
+    "tissue": "TESTES",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#214da6"
+  },
+  {
+    "ome": "PHOSPHO",
+    "tissue": "TESTES",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#214da6"
+  },
+  {
+    "ome": "ACETYL",
+    "tissue": "TESTES",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#214da6"
+  },
+  {
+    "ome": "UBIQ",
+    "tissue": "TESTES",
+    "omeType": "Proteomics",
+    "featureCnt": null,
+    "diffProportion": 0,
+    "omeColor": "#8DA0CB",
+    "tissueColor": "#214da6"
+  },
+  {
+    "ome": "IMMUNO",
+    "tissue": "TESTES",
+    "omeType": "Immunoassays",
+    "featureCnt": 4,
+    "diffProportion": 0.0869565217391304,
+    "omeColor": "#66C2A5",
+    "tissueColor": "#214da6"
+  },
+  {
+    "ome": "METAB",
+    "tissue": "TESTES",
+    "omeType": "Metabolomics",
+    "featureCnt": 44,
+    "diffProportion": 0.1,
+    "omeColor": "#E78AC3",
+    "tissueColor": "#214da6"
+  }
+]

--- a/src/LandingPage/components/figureTissueProps.json
+++ b/src/LandingPage/components/figureTissueProps.json
@@ -214,7 +214,7 @@
     ]
   },
   "TESTES": {
-    "label": "Testis",
+    "label": "Testes",
     "hoverLabelColor": "#6D86A5",
     "hoverLabelTextColor": "#FFFFFF",
     "assays": [

--- a/src/LandingPage/components/figureTissueProps.json
+++ b/src/LandingPage/components/figureTissueProps.json
@@ -1,0 +1,226 @@
+{
+  "BLOOD": {
+    "label": "Blood RNA",
+    "hoverLabelColor": "#D92C04",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rna-seq"
+    ]
+  },
+  "PLASMA": {
+    "label": "Plasma",
+    "hoverLabelColor": "#F1997C",
+    "hoverLabelTextColor": "#000000",
+    "assays": [
+      "metab",
+      "cytokine"
+    ]
+  },
+  "HEART": {
+    "label": "Heart",
+    "hoverLabelColor": "#F28B2F",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rrbs",
+      "atac-seq",
+      "rna-seq",
+      "prot-pr",
+      "prot-ph",
+      "prot-ac",
+      "prot-ub",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "VENACV": {
+    "label": "Vena Cava",
+    "hoverLabelColor": "#A5415B",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rna-seq"
+    ]
+  },
+  "SPLEEN": {
+    "label": "Spleen",
+    "hoverLabelColor": "#F3C288",
+    "hoverLabelTextColor": "#000000",
+    "assays": [
+      "rna-seq",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "SKM-GN": {
+    "label": "Gastrocnemius",
+    "hoverLabelColor": "#088C03",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rrbs",
+      "atac-seq",
+      "rna-seq",
+      "prot-pr",
+      "prot-ph",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "SKM-VL": {
+    "label": "Vastus Lateralis",
+    "hoverLabelColor": "#025939",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rna-seq",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "WAT-SC": {
+    "label": "White Adipose",
+    "hoverLabelColor": "#214DA6",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rrbs",
+      "atac-seq",
+      "rna-seq",
+      "prot-pr",
+      "prot-ph",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "BAT": {
+    "label": "Brown Adipose",
+    "hoverLabelColor": "#8C5220",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rrbs",
+      "atac-seq",
+      "rna-seq",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "LIVER": {
+    "label": "Liver",
+    "hoverLabelColor": "#DA6C75",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rrbs",
+      "atac-seq",
+      "rna-seq",
+      "prot-pr",
+      "prot-ph",
+      "prot-ac",
+      "prot-ub",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "LUNG": {
+    "label": "Lung",
+    "hoverLabelColor": "#04BF8A",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "atac-seq",
+      "rna-seq",
+      "prot-pr",
+      "prot-ph",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "KIDNEY": {
+    "label": "Kidney",
+    "hoverLabelColor": "#7553A7",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rrbs",
+      "atac-seq",
+      "rna-seq",
+      "prot-pr",
+      "prot-ph",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "ADRNL": {
+    "label": "Adrenal",
+    "hoverLabelColor": "#DDA0DD",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rna-seq",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "CORTEX": {
+    "label": "Cortex",
+    "hoverLabelColor": "#F2E751",
+    "hoverLabelTextColor": "#000000",
+    "assays": [
+      "rna-seq",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "HYPOTH": {
+    "label": "Hypothalamus",
+    "hoverLabelColor": "#F2B443",
+    "hoverLabelTextColor": "#000000",
+    "assays": [
+      "rna-seq",
+      "metab"
+    ]
+  },
+  "HIPPOC": {
+    "label": "Hippocampus",
+    "hoverLabelColor": "#BF7534",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "atac-seq",
+      "rna-seq",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "SMLINT": {
+    "label": "Small Intestine",
+    "hoverLabelColor": "#A18277",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rna-seq",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "COLON": {
+    "label": "Colon",
+    "hoverLabelColor": "#5A2E15",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rna-seq",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "OVARY": {
+    "label": "Ovary",
+    "hoverLabelColor": "#F2CED0",
+    "hoverLabelTextColor": "#000000",
+    "assays": [
+      "rna-seq",
+      "metab",
+      "cytokine"
+    ]
+  },
+  "TESTES": {
+    "label": "Testis",
+    "hoverLabelColor": "#6D86A5",
+    "hoverLabelTextColor": "#FFFFFF",
+    "assays": [
+      "rna-seq",
+      "metab",
+      "cytokine"
+    ]
+  }
+}

--- a/src/LandingPage/landingPage.jsx
+++ b/src/LandingPage/landingPage.jsx
@@ -12,10 +12,10 @@ import IconSet from '../lib/iconSet';
 
 import LayerRunner from '../assets/LandingPageGraphics/Data_Layer_Runner.png';
 import RatFigurePaass1b from '../assets/LandingPageGraphics/rat-figure-pass1b.svg';
-import DifferentialAnalytesHeatmap from '../assets/LandingPageGraphics/figure1c-differential-analytes-grid.svg';
 import TutorialVideoPreviewImage from '../assets/LandingPageGraphics/tutorial_video_preview_image.jpg';
 import LandscapePreprintAbstract from '../assets/LandingPageGraphics/landscape_preprint_abstract.jpg';
 import BackgroundVideo from './components/backgroundVideo';
+import Figure1C from './components/figure1c';
 
 // import figure 4E visualization dataset
 const figure4eData = require('../data/landscape_figure_4e.json');
@@ -252,13 +252,7 @@ export function LandingPage({ isAuthenticated, profile }) {
       <section className="fourth">
         <div className="w-100 h-100 d-flex align-items-center">
           <div className="section-content-container container-fluid text-center">
-            <Link to="/search">
-              <img
-                src={DifferentialAnalytesHeatmap}
-                className="img-fluid mb-4"
-                alt="Rat Figure - Endurance Training"
-              />
-            </Link>
+            <Figure1C />
             <div className="container text-center">
               <h1 className="py-4">
                 Visualize the number of training-differential features whose

--- a/src/LandingPage/landingPage.jsx
+++ b/src/LandingPage/landingPage.jsx
@@ -240,7 +240,7 @@ export function LandingPage({ isAuthenticated, profile }) {
               getNodes={getNodes}
             />
             <div className="container text-center">
-              <h1 className="py-4 text-white">
+              <h1 className="py-3 text-white">
                 A network of genes functionally related to longevity, muscle
                 system processes, and response to mechanical stimulus
               </h1>

--- a/src/sass/_landingPage.scss
+++ b/src/sass/_landingPage.scss
@@ -89,7 +89,7 @@
 
       .section-content-container {
         height: 75vh;
-        padding-top: 15px;
+        padding-top: 72px;
         padding-bottom: 15px;
 
         .vis-tooltip {
@@ -121,6 +121,11 @@
         img {
           margin-left: 15em;
           margin-right: 15em;
+
+          &.img-fluid {
+            max-width: 70%;
+            height: auto;
+          }
         }
       }
 
@@ -191,12 +196,12 @@
     }
     &.seventh {
       .section-content-container {
-        padding-top: 4.0em;
-        padding-bottom: 1.5em;
+        padding-top: 72px;
+        padding-bottom: 0;
 
         .content-code-repository {
           min-height: 560px;
-          margin-bottom: 5.0em;
+          margin-bottom: 3.0em;
 
           .feature-image {
             text-align: center;

--- a/src/sass/_landingPage.scss
+++ b/src/sass/_landingPage.scss
@@ -254,6 +254,78 @@ body.homepage {
       display: block;
     }
   }
+
+  #heatmap-container {
+    min-width: 1450px !important;
+    min-height: 610px;
+  }
+
+  .heatmap-y-axis {
+    .tick {
+      text {
+        font-size: 1.35rem;
+        font-weight: 800;
+      }
+    }
+    .tick:last-child,
+    .tick:nth-child(7),
+    .tick:nth-child(8) {
+      text {
+        fill: #FC8D62;
+      }
+    }
+    .tick:nth-child(3),
+    .tick:nth-child(4),
+    .tick:nth-child(5),
+    .tick:nth-child(6) {
+      text {
+        fill: #8DA0CB;
+      }
+    }
+    .tick:nth-child(2) {
+      text {
+        fill: #66C2A5;
+      }
+    }
+    .tick:first-child {
+      text {
+        fill: #E78AC3;
+      }
+    }
+  }
+
+  .heatmap-tooltip {
+    background: #000;
+    border-radius: 4px;
+    color: #ffffff;
+    font-size: 0.7rem;
+    font-weight: 600;
+    padding: 9px 13px;
+    position: absolute;
+    text-align: left;
+  }
+
+  .legend-title-diff-proportion,
+  .legend-title-ome-type {
+    tspan {
+      fill: #fff;
+      font-size: 1.0rem;
+    }
+  }
+  
+  .legend-y-axis {
+    font-size: 0.7rem;
+
+    .tick {
+      text {
+        fill: #fff;
+        font-size: 0.85rem;
+      }
+      text::before {
+        content: '%';
+      }
+    }
+  }
 }
 
 section.first {

--- a/src/sass/_landingPage.scss
+++ b/src/sass/_landingPage.scss
@@ -196,12 +196,12 @@
     }
     &.seventh {
       .section-content-container {
-        padding-top: 72px;
-        padding-bottom: 0;
+        padding-top: 4.0em;
+        padding-bottom: 1.5em;
 
         .content-code-repository {
           min-height: 560px;
-          margin-bottom: 3.0em;
+          margin-bottom: 5.0em;
 
           .feature-image {
             text-align: center;


### PR DESCRIPTION
### Key Changes:

Deprecated the static Figure 1C SVG image on the redesigned homepage, and replaced it with an interactive plot natively built with *D3*.