### PR TITLE
Bump node version to v20.11.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/node:16.20.0-browsers
+      - image: cimg/node:20.11.0-browsers
 
     steps:
       - checkout


### PR DESCRIPTION
### Key Change:

Bumping `node` version to `v20.11.0` due to its incompatibility with `polished@4.3.0` during `yarn install`, including `circleci` config.