### PR TITLE
Bump dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
     "tocbot": "^4.25.0",
-    "victory": "36.9.1",
+    "victory": "36.9.2",
     "vis-data": "^7.1.7",
     "vis-network": "^9.1.8",
     "vis-network-react": "^1.3.6"


### PR DESCRIPTION
### Key Changes:

Bump `victory` dependency version due to failed production build during deployment.