### PR TITLE
Connects to #300. Connects to #301. New UI for clinical study protocols and MOPs. Updated links to HERITAGE proteomics data files.

### DIFF
--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -30,6 +30,7 @@ import Tutorials from '../Tutorials/tutorials';
 import Publications from '../Publications/publications';
 import MultiOmicsWorkingGroups from '../MultiOmicsWorkingGroups/multiOmicsWorkingGroups';
 import FullTableEnduranceTraining from '../Publications/Data/Animal/Phenotype/fullTableEnduranceTraining';
+import ClinicalStudyProtocols from '../Publications/Docs/Protocol/Clinical/clinicalStudyProtocols';
 import Pass1b06PhenotypeAnimalConnected from '../AnalysisPage/pass1b06PhenotypeAnimal';
 import CallbackConnected from '../Auth/callback';
 import { withTracker } from '../GoogleAnalytics/googleAnalytics';
@@ -140,6 +141,11 @@ function App({ history = History }) {
                 path="/publications/data/animal/phenotype/full-table-endurance-training"
                 exact
                 component={withTracker(FullTableEnduranceTraining)}
+              />
+              <PrivateRoute
+                path="/publications/docs/protocol/clinical/study-protocols"
+                exact
+                component={withTracker(ClinicalStudyProtocols)}
               />
               <PrivateRoute
                 path="/analysis-phenotype"

--- a/src/App/__test__/App.test.jsx
+++ b/src/App/__test__/App.test.jsx
@@ -27,7 +27,7 @@ describe('<App />', () => {
   });
 
   test('It should contain four <PrivateRoute /> children', () => {
-    expect(component.find('PrivateRoute').length).toBe(6);
+    expect(component.find('PrivateRoute').length).toBe(7);
   });
 });
 

--- a/src/Navbar/navbar.jsx
+++ b/src/Navbar/navbar.jsx
@@ -324,6 +324,14 @@ export function Navbar({
                   >
                     OmicsPipelines
                   </a>
+                  {isAuthenticated && hasAccess && userType === 'internal' ? (
+                    <Link
+                      to="/publications/docs/protocol/clinical/study-protocols"
+                      className="dropdown-item"
+                    >
+                      Clinical Study Protocols
+                    </Link>
+                  ) : null}
                 </div>
               </li>
               <li className="nav-item navItem dropdown">

--- a/src/Publications/Docs/Protocol/Clinical/clinicalStudyProtocols.jsx
+++ b/src/Publications/Docs/Protocol/Clinical/clinicalStudyProtocols.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
+import PageTitle from '../../../../lib/ui/pageTitle';
+
+function ClinicalStudyProtocols() {
+  // get states from redux store
+  const userProfile = useSelector((state) => state.auth.profile);
+
+  const userType =
+    userProfile.user_metadata && userProfile.user_metadata.userType;
+
+  if (userType !== 'internal') {
+    return <Redirect to="/search" />;
+  }
+
+  return (
+    <div className="clinicalStudyProtocolsPage px-3 px-md-4 mb-3 container">
+      <Helmet>
+        <html lang="en" />
+        <title>MoTrPAC Clinical Study Protocols and MOPs</title>
+      </Helmet>
+      <PageTitle title="MoTrPAC Clinical Study Protocols and MOPs" />
+      <div className="clinical-study-protocols-container">
+        <div className="clinical-study-protocols-content-container mt-5">
+          <p>
+            <a
+              href="https://drive.google.com/file/d/1-XvXVV2iLfg5q-b7GmLQ1Dd_GFqbnhs5/view?usp=sharing"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Adult_Combined_MOPs_2024_03_28.pdf
+            </a>
+          </p>
+          <p>
+            <a
+              href="https://drive.google.com/file/d/1nCJAgLKVxgzVwGm8qPMM-3co4pYuRdRY/view?usp=sharing"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              MoTrPAC_Adult_Protocol_v3.0_2023_08_22_clean.pdf
+            </a>
+          </p>
+          <p>
+            <a
+              href="https://drive.google.com/file/d/1L82fU6Ex09rxuYbi6Xxk-QPv3o64R2rM/view?usp=sharing"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Pediatric_Clinical_Protocol_Version_v8.12_2023_03_14.pdf
+            </a>
+          </p>
+          <p>
+            <a
+              href="https://drive.google.com/file/d/1rfJLN3ELxT02139xN5BITG_LfrvSLIxJ/view?usp=sharing"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Peds_Combined_MOPs_2024_01_08.pdf
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ClinicalStudyProtocols;

--- a/src/RelatedStudy/heritageProteomics.jsx
+++ b/src/RelatedStudy/heritageProteomics.jsx
@@ -98,7 +98,9 @@ function HeritageProteomics() {
             <div className="mx-3 d-flex align-items-center">
               <a
                 download
-                href="http://related-studies.motrpac-data.org/heritage_proteomics/HERITAGE_proteomics_somalogic.xlsx"
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://drive.google.com/file/d/1XOdx__kqZYuEkLHnDuBqRPho50w3sNG3/view?usp=sharing"
                 className="btn btn-outline-primary d-flex align-items-center"
                 role="button"
               >
@@ -117,7 +119,9 @@ function HeritageProteomics() {
             <div className="mx-3 d-flex align-items-center">
               <a
                 download
-                href="http://related-studies.motrpac-data.org/heritage_proteomics/HERITAGE_somalogic_analytes.xlsx"
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://drive.google.com/file/d/1eNj4AmspK7UH74odeDDZpfBA1CNKghFA/view?usp=sharing"
                 className="btn btn-outline-primary d-flex align-items-center"
                 role="button"
               >


### PR DESCRIPTION
### Key Changes;

* Implemented new page to host links to MoTrPAC clinical study protocols and MOPs with temporary restricted access to internal users until manuscript is accepted at JAP.
* Changed HERITAGE proteomics data file links (see `/related-studies/heritage-proteomics`) to zipped files on Google Drive due to the deprecation of publicly accessible GCP bucket.