### PR TITLE
Connects to #331. Graphical clustering timecourse visualization link.

### DIFF
--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/ADRNL.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/ADRNL.jsx
@@ -153,6 +153,11 @@ function GraphicalAnalysisAdrenal() {
                   <img src={`${imageURL}/figure_6.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Adrenal"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/BAT.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/BAT.jsx
@@ -154,6 +154,11 @@ function GraphicalAnalysisBrownAdipose() {
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Brown Adipose"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/BLOOD.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/BLOOD.jsx
@@ -147,6 +147,11 @@ function GraphicalAnalysisBlood() {
                   <img src={`${imageURL}/figure_6.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Blood RNA"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/COLON.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/COLON.jsx
@@ -149,6 +149,11 @@ function GraphicalAnalysisColon() {
                   <img src={`${imageURL}/figure_6.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Colon"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/CORTEX.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/CORTEX.jsx
@@ -150,6 +150,11 @@ function GraphicalAnalysisCortex() {
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Cortex"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/HEART.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/HEART.jsx
@@ -149,6 +149,11 @@ function GraphicalAnalysisHeart() {
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_9.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Heart"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/HIPPOC.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/HIPPOC.jsx
@@ -154,6 +154,11 @@ function GraphicalAnalysisHippocampus() {
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Hippocampus"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/HYPOTH.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/HYPOTH.jsx
@@ -40,6 +40,7 @@ function GraphicalAnalysisHypothalamus() {
                 title="trajectory"
                 tissue="Hypothalamus"
                 plotType="Tree"
+                minClusterSize={1}
               />
             </div>
             <div className="section level3">
@@ -55,6 +56,7 @@ function GraphicalAnalysisHypothalamus() {
                 title="cluster"
                 tissue="Hypothalamus"
                 plotType="Histogram"
+                minClusterSize={1}
               />
             </div>
           </div>

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/KIDNEY.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/KIDNEY.jsx
@@ -145,6 +145,11 @@ function GraphicalAnalysisKidney() {
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_9.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Kidney"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/LIVER.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/LIVER.jsx
@@ -145,6 +145,11 @@ function GraphicalAnalysisLiver() {
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_9.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Liver"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/LUNG.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/LUNG.jsx
@@ -141,6 +141,11 @@ function GraphicalAnalysisLung() {
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_9.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Lung"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/PLASMA.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/PLASMA.jsx
@@ -143,6 +143,11 @@ function GraphicalAnalysisPlasma() {
                   <img src={`${imageURL}/figure_6.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Plasma"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
             </div>

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/SKM_GN.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/SKM_GN.jsx
@@ -155,6 +155,11 @@ function GraphicalAnalysisGastrocnemius() {
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_9.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Gastrocnemius"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/SKM_VL.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/SKM_VL.jsx
@@ -147,6 +147,11 @@ function GraphicalAnalysisVastusLateralis() {
                   <img src={`${imageURL}/figure_6.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Vastus Lateralis"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/SMLINT.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/SMLINT.jsx
@@ -147,6 +147,11 @@ function GraphicalAnalysisSmallIntestine() {
                   <img src={`${imageURL}/figure_6.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Small Intestine"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/SPLEEN.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/SPLEEN.jsx
@@ -143,6 +143,11 @@ function GraphicalAnalysisSpleen() {
                   <img src={`${imageURL}/figure_6.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Spleen"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/WAT_SC.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bLandscapeTissues/WAT_SC.jsx
@@ -149,6 +149,11 @@ function GraphicalAnalysisWhiteAdipose() {
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_9.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="White Adipose"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/ADRNL.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/ADRNL.jsx
@@ -150,6 +150,11 @@ function MitoGraphicalAnalysisAdrenal() {
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Adrenal"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/BAT.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/BAT.jsx
@@ -150,6 +150,11 @@ function MitoGraphicalAnalysisBrownAdipose() {
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Brown Adipose"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/BLOOD.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/BLOOD.jsx
@@ -150,6 +150,11 @@ function MitoGraphicalAnalysisBlood() {
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Blood RNA"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/COLON.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/COLON.jsx
@@ -146,6 +146,11 @@ function MitoGraphicalAnalysisColon() {
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Colon"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/HEART.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/HEART.jsx
@@ -147,6 +147,11 @@ function MitoGraphicalAnalysisHeart() {
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_9.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Heart"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/KIDNEY.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/KIDNEY.jsx
@@ -146,6 +146,11 @@ function MitoGraphicalAnalysisKidney() {
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Kidney"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/LIVER.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/LIVER.jsx
@@ -147,6 +147,11 @@ function MitoGraphicalAnalysisLiver() {
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_9.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Liver"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/LUNG.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/LUNG.jsx
@@ -137,6 +137,11 @@ function MitoGraphicalAnalysisLung() {
                   <img src={`${imageURL}/figure_6.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Lung"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/SKM_GN.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/SKM_GN.jsx
@@ -150,6 +150,11 @@ function MitoGraphicalAnalysisGastrocnemius() {
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Gastrocnemius"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/SKM_VL.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/SKM_VL.jsx
@@ -150,6 +150,11 @@ function MitoGraphicalAnalysisVastusLateralis() {
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Vastus Lateralis"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/SMLINT.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/SMLINT.jsx
@@ -148,6 +148,11 @@ function MitoGraphicalAnalysisSmallIntestine() {
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Small Intestine"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
             </div>

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/SPLEEN.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/SPLEEN.jsx
@@ -147,6 +147,11 @@ function MitoGraphicalAnalysisSpleen() {
                   No significant enrichments for
                   SPLEEN:1w_F0_M0-&gt;2w_F0_M0-&gt;4w_F0_M0-&gt;8w_F1_M1
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="Spleen"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
             </div>

--- a/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/WAT_SC.jsx
+++ b/src/AnalysisPage/GraphicalClustering/Pass1bMitoTissues/WAT_SC.jsx
@@ -150,6 +150,11 @@ function MitoGraphicalAnalysisWhiteAdipose() {
                   <img src={`${imageURL}/figure_7.png`} width="100%" alt="" />
                   <img src={`${imageURL}/figure_8.png`} width="100%" alt="" />
                 </p>
+                <DataVizLink
+                  title="timecourse"
+                  tissue="White Adipose"
+                  plotType="Trajectories"
+                />
                 <hr />
               </div>
               <div className="section level4">

--- a/src/AnalysisPage/GraphicalClustering/components/dataVizLink.jsx
+++ b/src/AnalysisPage/GraphicalClustering/components/dataVizLink.jsx
@@ -1,8 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function DataVizLink({ title, tissue, plotType }) {
-  const url = `https://data-viz.motrpac-data.org/?tissues[${tissue}]=1&plot_type=${plotType}&topk=10`;
+function DataVizLink({ title, tissue, plotType, minClusterSize }) {
+  let topkStr = '';
+  let minClusterSizeStr = '';
+
+  // include 'topk' param for non-trajectory plots
+  if (plotType !== 'Trajectories') {
+    topkStr = '&topk=10';
+  }
+
+  // include 'min_cluster_size' param if minClusterSize is provided
+  if (minClusterSize && typeof (minClusterSize) === 'number') {
+    minClusterSizeStr = `&min_cluster_size=${minClusterSize}`;
+  }
+
+  const url = `https://data-viz.motrpac-data.org/?tissues[${tissue}]=1&plot_type=${plotType}${topkStr}${minClusterSizeStr}`;
 
   return (
     <p className="data-visualization-link-container text-center">
@@ -23,6 +36,11 @@ DataVizLink.propTypes = {
   title: PropTypes.string.isRequired,
   tissue: PropTypes.string.isRequired,
   plotType: PropTypes.string.isRequired,
+  minClusterSize: PropTypes.number,
+};
+
+DataVizLink.defaultProps = {
+  minClusterSize: null,
 };
 
 export default DataVizLink;

--- a/src/AnnouncementsPage/announcements.json
+++ b/src/AnnouncementsPage/announcements.json
@@ -136,6 +136,27 @@
     {
         "aid": 7,
         "posted_date": "2024-05-01",
+        "title": "MoTrPAC gene regulation study published in Nature Communications",
+        "content": "This study integrated MoTrPAC multi-tissue differential gene expression results with external genetic, transcriptomic, and other data. Several computational approaches were leveraged to explore possible ways in which exercise may modulate complex trait variation, including disease severity and risk.",
+        "metadata": {
+            "target": "external",
+            "tags": [
+                "companion-paper-published"
+            ],
+            "icon": "auto_stories"
+        },
+        "links": [
+            {
+                "label": "The impact of exercise on gene regulation in association with complex trait genetics",
+                "url": "https://doi.org/10.1038/s41467-024-45966-w",
+                "gaEventCategory": "MoTrPAC Companion Paper",
+                "gaEventAction": "Nature Publication"
+            }
+        ]
+    },
+    {
+        "aid": 8,
+        "posted_date": "2024-05-01",
         "title": "MoTrPAC animal molecular adaptations study published in Cell Genomics",
         "content": "In an integrated analysis of DNA methylation, chromatin accessibility, and transcriptome in eight tissues from the control group, we identified distinct molecular landscapes across rat tissues. We demonstrated that the transcriptional and epigenetic responses to eight weeks of exercise training are predominantly tissue-specific and implicated GPCR-encoding genes as potential mediators of the molecular adaptations to training.",
         "metadata": {
@@ -155,7 +176,7 @@
         ]
     },
     {
-        "aid": 8,
+        "aid": 9,
         "posted_date": "2024-05-01",
         "title": "MoTrPAC animal physiological adaptations study published in Function",
         "content": "This paper extensively characterizes physiological adaptations to progressive endurance exercise in fully mature adult and aged rats, serving as a phenotypic compendium of the MoTrPAC pre-clinical animal endurance training data resource. Ultimately, the goal of this resource is to foster phenotypic and multi-omic data integration to develop an integrative molecular map of time-, sex-, and age-specific responses to endurance exercise training.",
@@ -176,7 +197,7 @@
         ]
     },
     {
-        "aid": 9,
+        "aid": 10,
         "posted_date": "2024-05-01",
         "title": "MoTrPAC animal white adipose tissue study published in Nature Metabolism",
         "content": "Multi-omic profiling identifies profound sexual dimorphism in the subcutaneous white adipose tissue (scWAT) molecular landscape of sedentary rats that is largely preserved or amplified with training.  Using a computational approach, we identify candidate molecular regulators of sexually dimorphic scWAT phenotypic responses to training, demonstrating the resource utility of MoTrPAC-generate data to drive novel hypothesis-based research in the field.",
@@ -197,7 +218,7 @@
         ]
     },
     {
-        "aid": 10,
+        "aid": 11,
         "posted_date": "2024-05-01",
         "title": "MoTrPAC animal endurance training study published in Nature",
         "content": "The main MoTrPAC animal endurance training study has been published in Nature. This study profiled the temporal transcriptome, proteome, metabolome, lipidome, phosphoproteome, acetylproteome, ubiquitylproteome, epigenome, and immunome in whole blood, plasma, and 18 solid tissues in male and female rats over 8 weeks of endurance exercise training. The resulting data compendium encompasses 9466 assays across 19 tissues, 25 molecular platforms, and 4 training time points in young adult male and female rats.",
@@ -224,7 +245,7 @@
         ]
     },
     {
-        "aid": 11,
+        "aid": 12,
         "posted_date": "2024-05-02",
         "title": "MoTrPAC mitochondrial response study published in Cell Metabolism",
         "content": "The MoTrPAC Mitochondria companion paper has been published in the Cell Metabolism. This study provides a multi-omic, cross-tissue atlas of the mitochondrial response to training and identify candidates for prevention of disease-associated mitochondrial dysfunction.",


### PR DESCRIPTION
### Key Changes:

* For the first timecourse trajectory plots of individual tissue-level graphical analysis reports, added links to respective `data-viz` portal visualizations.
* Added support for visualization links to include `min_cluster_size` param.
* Added announcement item for Nik's companion paper in Nature Comm.