### PR TITLE
Connects to #367. DAWG-PAC analysis resources update.

### DIFF
--- a/public/static-assets/dawg-pac/phenotypes/pass1ac-pheno-analysis.html
+++ b/public/static-assets/dawg-pac/phenotypes/pass1ac-pheno-analysis.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>PASS1A/1C-06 Phenotypic Data Analysis</title>
+</head>
+<body class="preload">
+<h1 class="title">PASS1A/1C-06 Phenotypic Data Analysis</h1>
+</body>
+</html>

--- a/src/MultiOmicsWorkingGroups/dawgPAC.jsx
+++ b/src/MultiOmicsWorkingGroups/dawgPAC.jsx
@@ -111,6 +111,31 @@ function DawgPAC({ profile }) {
           Integrated R Notebooks for Omics Data Analysis (HTML format)
           <ul className="list-style mt-2">
             <li>
+              Phenotypes
+              <ul className="list-style mb-2">
+                <li>
+                  Comprehensive analysis of key variables from the rat phenotypic data,
+                  including summary statistics, correlation analysis, statistical
+                  testing, and regression models:
+                  {' '}
+                  {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                  <a
+                    href="#"
+                    data-toggle="modal"
+                    data-target="#html-report-modal"
+                    onClick={(e) =>
+                      handleClickReport(
+                        'phenotypes/pass1ac-pheno-analysis.html',
+                        'pass1ac-pheno-analysis.html',
+                      )
+                    }
+                  >
+                    pass1ac-pheno-analysis.html
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li>
               Transcriptomics
               <ul className="list-style mb-2">
                 <li>


### PR DESCRIPTION
### Key Changes:

* Added new DAWG-PAC analysis list item for phenotype with a link to the notebook file.