### PR TITLE
Fix code scanning alert no. 2: Missing regular expression anchor

### DIFF
--- a/src/GoogleAnalytics/googleAnalytics.jsx
+++ b/src/GoogleAnalytics/googleAnalytics.jsx
@@ -12,7 +12,7 @@ const trackingId = () => {
   let analyticsTrackerHostname = document.location.hostname;
 
   // match hostname to google analytics domain identified for tracker
-  if (/^(www\.)?motrpac(-[a-z]+)?.org/.test(analyticsTrackerHostname)) {
+  if (/^(www\.)?motrpac(-[a-z]+)?.org$/.test(analyticsTrackerHostname)) {
     // production app
     analyticsTrackerHostname = 'www.motrpac-data.org';
   } else {


### PR DESCRIPTION
Fixes [https://github.com/MoTrPAC/motrpac-frontend/security/code-scanning/2](https://github.com/MoTrPAC/motrpac-frontend/security/code-scanning/2)

To fix the problem, we need to add an anchor at the end of the regular expression to ensure it matches the entire hostname string. This can be done by adding a `$` at the end of the pattern. This change will ensure that only hostnames that exactly match the specified pattern will be considered valid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
