### PR TITLE
Use full checkout method in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,8 @@ jobs:
       - image: cimg/node:20.19.5-browsers
 
     steps:
-      - checkout
+      - checkout:
+          method: full
 
       - run:
           name: Enable Corepack


### PR DESCRIPTION
### Key Change

Updated the CircleCI configuration to use the 'full' checkout method, ensuring all repository data is available during CI jobs.