### PR TITLE
[PATCH] Add precawg data release notes link

### DIFF
--- a/src/BrowseDataPage/components/dataDownloadsMain.jsx
+++ b/src/BrowseDataPage/components/dataDownloadsMain.jsx
@@ -210,7 +210,7 @@ function DataDownloadsMain({
                 <li>22 assays across different omes</li>
                 {import.meta.env.VITE_DATA_RELEASE_README ? (
                   <li>
-                    <a href="https://d1yw74buhe0ts0.cloudfront.net/docs/MoTrPAC_Human_PreSuspension_Sed_Adu_Analysis_Data_Release_Notes.pdf" target="_blank" rel="noopener noreferrer">
+                    <a href={import.meta.env.VITE_DATA_RELEASE_README} target="_blank" rel="noopener noreferrer">
                       <i className="bi bi-file-earmark-fill mr-1" />
                       <span>Data Release Notes</span>
                     </a>

--- a/src/BrowseDataPage/components/selectiveDataDownloads.jsx
+++ b/src/BrowseDataPage/components/selectiveDataDownloads.jsx
@@ -85,7 +85,7 @@ function SelectiveDataDownloads({
           set of human data representing a subset of sedentary adults who underwent an acute
           exercise bout before the study was suspended due to COVID-19. Please refer to the
           {' '}
-          <a href="https://d1yw74buhe0ts0.cloudfront.net/docs/MoTrPAC_Human_PreSuspension_Sed_Adu_Analysis_Data_Release_Notes.pdf" target="_blank" rel="noopener noreferrer">
+          <a href={import.meta.env.VITE_DATA_RELEASE_README} target="_blank" rel="noopener noreferrer">
             Data Release Notes
           </a>
           {' '}

--- a/src/Search/components/differentialAbundanceSummary.jsx
+++ b/src/Search/components/differentialAbundanceSummary.jsx
@@ -17,7 +17,7 @@ function DifferentialAbundanceSummary({ userType = '' }) {
               sedentary adults randomized to endurance exercise training (EE), resistance
               exercise training (RE), or no-exercise control groups. Please refer to the
               {' '}
-              <a href="https://d1yw74buhe0ts0.cloudfront.net/docs/MoTrPAC_Human_PreSuspension_Sed_Adu_Analysis_Data_Release_Notes.pdf" target="_blank" rel="noopener noreferrer">
+              <a href={import.meta.env.VITE_DATA_RELEASE_README} target="_blank" rel="noopener noreferrer">
                 Data Release Notes
               </a>
               {' '}
@@ -30,7 +30,7 @@ function DifferentialAbundanceSummary({ userType = '' }) {
               young adult rats, as well as the pre-suspension human sedentary adults
               randomized to acute exercise or no-exercise control groups. Please refer to the
               {' '}
-              <a href="https://d1yw74buhe0ts0.cloudfront.net/docs/MoTrPAC_Human_PreSuspension_Sed_Adu_Analysis_Data_Release_Notes.pdf" target="_blank" rel="noopener noreferrer">
+              <a href={import.meta.env.VITE_DATA_RELEASE_README} target="_blank" rel="noopener noreferrer">
                 Data Release Notes
               </a>
               {' '}


### PR DESCRIPTION
### Key Changes

* Add precawg data release notes to file download browser page
* Add precawg data release notes to summary-level results search page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation Updates**
  * Added Data Release Notes links to dataset summary sections for easier access.
  * Replaced inline example guidance in search with references to the Data Release Notes.
  * Clarified search instructions and added a paragraph explaining use of auto-suggested search terms (type first few characters).
  * Updated dataset card links to use a centralized Data Release Notes URL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->