### PR TITLE
[FEATURE] PASS1B-06 2.0 (RN7) data public release

### DIFF
--- a/src/BrowseDataPage/browseDataActions.js
+++ b/src/BrowseDataPage/browseDataActions.js
@@ -131,15 +131,10 @@ function resetBrowseState() {
   };
 }
 
-function selectPass1B06Data(userType = null, files = pass1b06) {
-  // Filter out RN7 files for non-internal users
-  const filteredFiles = userType === 'internal' 
-    ? files 
-    : files.filter((file) => file.reference_genome !== 'RN7');
-  
+function selectPass1B06Data(files = pass1b06) {
   return {
     type: SELECT_PASS1B_06_DATA,
-    files: filteredFiles,
+    files,
   };
 }
 

--- a/src/BrowseDataPage/components/bundleDatasets.jsx
+++ b/src/BrowseDataPage/components/bundleDatasets.jsx
@@ -120,7 +120,7 @@ function BundleDatasets({
                   bundlefileSize={item.object_zipfile_size}
                   profile={profile}
                 />
-                {item.object_rn7_zipfile && profile?.user_metadata?.userType === 'internal' && (
+                {item.object_rn7_zipfile && (
                   <>
                     <div className="text-center text-muted my-1">- or -</div>
                     <BundleDownloadButton

--- a/src/BrowseDataPage/components/dataDownloadsMain.jsx
+++ b/src/BrowseDataPage/components/dataDownloadsMain.jsx
@@ -154,7 +154,7 @@ function DataDownloadsMain({
             <SelectiveDataDownloadsCard
               cardIcon="pest_control_rodent"
               cardTitle="Young Adult Rats"
-              dataSelectHandler={() => dispatch(actions.selectPass1B06Data(userType))}
+              dataSelectHandler={() => dispatch(actions.selectPass1B06Data())}
               selectedData="pass1b-06"
               cssSelector={
                 !userType || (userType && userType === 'external')


### PR DESCRIPTION
This pull request removes user-type-based filtering for the PASS1B-06 dataset, making all files (including those with the `RN7` reference genome) available to all users. The logic for displaying RN7-specific download options in the UI has also been updated to remove the internal-user restriction.

Data access and UI logic changes:

* The `selectPass1B06Data` action no longer filters out RN7 files for non-internal users; all files are now included regardless of user type (`browseDataActions.js`).
* The RN7 download button in the `BundleDatasets` component is now always displayed when available, without checking if the user is internal (`bundleDatasets.jsx`).
* The `dataSelectHandler` for "Young Adult Rats" in `DataDownloadsMain` no longer passes the user type, aligning with the updated action signature (`dataDownloadsMain.jsx`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Data Access**
  * RN7 download option is now available to all users whenever the dataset exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->