### PR TITLE
[BUG] Top nav Dashboard link showing for unauthorized users

### DIFF
--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import FeatureLinks from '../Search/featureLinks';
 import DataStatusActions from '../DataStatusPage/dataStatusActions';

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -18,10 +18,16 @@ import '@styles/dashboard.scss';
  */
 export function Dashboard({ 
   profile = {}, 
+  isAuthenticated = false,
   handleQCDataFetch, 
   lastModified = '',
 }) {
   const userType = profile.user_metadata && profile.user_metadata.userType;
+  const hasAccess = profile.user_metadata && profile.user_metadata.hasAccess;
+
+  if (!isAuthenticated || !hasAccess) {
+    return <Navigate to="/" />;
+  }
 
   return (
     <div className="dashboardPage px-3 px-md-4 mb-3">
@@ -206,6 +212,7 @@ Dashboard.propTypes = {
   profile: PropTypes.shape({
     user_metadata: PropTypes.object,
   }),
+  isAuthenticated: PropTypes.bool,
   handleQCDataFetch: PropTypes.func.isRequired,
   lastModified: PropTypes.string,
 };

--- a/src/Navbar/__test__/navbar.test.jsx
+++ b/src/Navbar/__test__/navbar.test.jsx
@@ -48,4 +48,39 @@ describe('Navbar', () => {
     expect(screen.getByText(/learn/i)).toBeInTheDocument();
     expect(screen.getByText(/about/i)).toBeInTheDocument();
   });
+
+  test('shows Dashboard link for authenticated users with access', () => {
+    renderWithProviders(
+      <Navbar
+        profile={testUser}
+        isAuthenticated={true}
+        {...mockActions}
+      />
+    );
+
+    expect(screen.getByText(/dashboard/i)).toBeInTheDocument();
+  });
+
+  test('hides Dashboard link for unauthenticated users', () => {
+    renderWithProviders(<Navbar />);
+
+    expect(screen.queryByText(/dashboard/i)).not.toBeInTheDocument();
+  });
+
+  test('hides Dashboard link for users without access', () => {
+    const noAccessUser = {
+      ...testUser,
+      user_metadata: { ...testUser.user_metadata, hasAccess: false },
+    };
+
+    renderWithProviders(
+      <Navbar
+        profile={noAccessUser}
+        isAuthenticated={true}
+        {...mockActions}
+      />
+    );
+
+    expect(screen.queryByText(/dashboard/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/Navbar/navbar.jsx
+++ b/src/Navbar/navbar.jsx
@@ -198,11 +198,13 @@ export function Navbar({
                   </Link>
                 </li>
               )}
-              <li className="nav-item navItem">
-                <Link to="/dashboard" className="nav-link">
-                  Dashboard
-                </Link>
-              </li>
+              {isAuthenticated && hasAccess && (
+                <li className="nav-item navItem">
+                  <Link to="/dashboard" className="nav-link">
+                    Dashboard
+                  </Link>
+                </li>
+              )}
               <li className="nav-item navItem dropdown">
                 <div
                   className="nav-link dropdown-toggle"

--- a/src/Navbar/navbar.jsx
+++ b/src/Navbar/navbar.jsx
@@ -121,6 +121,8 @@ export function Navbar({
 
   const hasAccess = profile.user_metadata && profile.user_metadata.hasAccess;
   const userType = profile.user_metadata && profile.user_metadata.userType;
+  const isAuthorized = isAuthenticated && hasAccess;
+  const isInternalUser = isAuthorized && userType === 'internal';
 
   // Call to invoke Redux action to fetch QC data
   // if timestamp is empty or older than 24 hours
@@ -186,7 +188,7 @@ export function Navbar({
             id="navbarSupportedContent"
           >
             <ul className="navbar-nav">
-              {isAuthenticated && hasAccess && userType === 'internal' && (
+              {isInternalUser && (
                 <li className="nav-item navItem">
                   <Link
                     to="/exerwise"
@@ -198,7 +200,7 @@ export function Navbar({
                   </Link>
                 </li>
               )}
-              {isAuthenticated && hasAccess && (
+              {isAuthorized && (
                 <li className="nav-item navItem">
                   <Link to="/dashboard" className="nav-link">
                     Dashboard
@@ -227,7 +229,7 @@ export function Navbar({
                   <Link
                     id="reg_user"
                     to={
-                      isAuthenticated && hasAccess
+                      isAuthorized
                         ? '/releases'
                         : '/data-access'
                     }
@@ -240,7 +242,7 @@ export function Navbar({
                   <Link to="/data-deposition" className="dropdown-item">
                     Public Data Repositories
                   </Link>
-                  {isAuthenticated && hasAccess && userType === 'internal' && (
+                  {isInternalUser && (
                     <>
                       <Link to="/biospecimen-summary" className="dropdown-item">
                         Biospecimens
@@ -256,7 +258,7 @@ export function Navbar({
                       </Link>
                     </>
                   )}
-                  {isAuthenticated && hasAccess && (
+                  {isAuthorized && (
                     <>
                       <Link to="/summary" className="dropdown-item">
                         Sample Summary
@@ -408,7 +410,7 @@ export function Navbar({
                   <Link to="/glossary" className="dropdown-item">
                     Glossary
                   </Link>
-                  {isAuthenticated && hasAccess && userType && userType === 'internal' && (
+                  {isInternalUser && (
                     <Link to="/exerwise" className="dropdown-item has-icon">
                       <span>ExerWise</span>
                       <i className="material-icons dropdown-item-icon ai-icon">auto_awesome</i>


### PR DESCRIPTION
This pull request makes a small update to the navigation bar to improve access control. The "Dashboard" link is now only shown to users who are both authenticated and have the appropriate access permissions.

- Only display the "Dashboard" navigation link if the user is authenticated and has access (`src/Navbar/navbar.jsx`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation updates: internal-only entries (including ExerWise and Sample Summary) and the dashboard link are shown only when users meet both authentication and access requirements; one release route target now follows the same gating.
  * Dashboard now redirects unauthenticated or no-access users away from dashboard pages.

* **Tests**
  * Added tests covering conditional visibility of the Dashboard navigation link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->