### PR TITLE
[FEATURE] PreCAWG clinical chemistry data download

### DIFF
--- a/src/BrowseDataPage/components/bundleDataTypes.js
+++ b/src/BrowseDataPage/components/bundleDataTypes.js
@@ -314,8 +314,7 @@ const BundleDataTypes = {
       study_group: 'Pre-Suspension',
       description:
         'Differential analysis, metadata, QC normalized data across human tissues for ATAC-seq and Methylcap-seq assays.',
-      object_zipfile:
-        'bundles/motrpac_human-precovid-sed-adu_epigenomics.zip',
+      object_zipfile: 'bundles/motrpac_human-precovid-sed-adu_epigenomics.zip',
       object_zipfile_size: '2.79 GB',
     },
     {
@@ -342,8 +341,7 @@ const BundleDataTypes = {
       study_group: 'Pre-Suspension',
       description:
         'Differential analysis, metadata, QC normalized data across human tissues for Global Proteomics, Phosphoproteomics, and OLink.',
-      object_zipfile:
-        'bundles/motrpac_human-precovid-sed-adu_proteomics.zip',
+      object_zipfile: 'bundles/motrpac_human-precovid-sed-adu_proteomics.zip',
       object_zipfile_size: '346.55 MB',
     },
     {

--- a/src/BrowseDataPage/components/bundleDataTypes.js
+++ b/src/BrowseDataPage/components/bundleDataTypes.js
@@ -374,6 +374,20 @@ const BundleDataTypes = {
         'bundles/motrpac_human-precovid-sed-adu_metabolomics-targeted.zip',
       object_zipfile_size: '25 MB',
     },
+    {
+      type: 'clinical-chemistry',
+      phase: 'human-precovid-sed-adu',
+      title: 'Clinical chemistry',
+      species: 'Human',
+      participant_type: 'Adult',
+      intervention: 'Sedentary',
+      study_group: 'Pre-Suspension',
+      description:
+        'Differential analysis, metadata, QC normalized data from human blood tissue for clinical chemistry experiment.',
+      object_zipfile:
+        'bundles/motrpac_human-precovid-sed-adu_clinical-chemistry.zip',
+      object_zipfile_size: '22.54 MB',
+    },
   ],
   human_sed_adu_external: [
     {
@@ -445,6 +459,20 @@ const BundleDataTypes = {
       object_zipfile:
         'bundles/external/motrpac_human-presuspension-sed-adu_metabolomics-targeted.zip',
       object_zipfile_size: '22.9 MB',
+    },
+    {
+      type: 'clinical-chemistry',
+      phase: 'human-precovid-sed-adu',
+      title: 'Clinical chemistry',
+      species: 'Human',
+      participant_type: 'Adult',
+      intervention: 'Sedentary',
+      study_group: 'Pre-Suspension',
+      description:
+        'Summary-level results and metadata human blood tissue for clinical chemistry experiment.',
+      object_zipfile:
+        'bundles/external/motrpac_human-presuspension-sed-adu_clinical-chemistry.zip',
+      object_zipfile_size: '22.44 MB',
     },
   ],
 };

--- a/src/BrowseDataPage/components/bundleDataTypes.js
+++ b/src/BrowseDataPage/components/bundleDataTypes.js
@@ -381,7 +381,7 @@ const BundleDataTypes = {
       intervention: 'Sedentary',
       study_group: 'Pre-Suspension',
       description:
-        'Differential analysis, metadata, QC normalized data from human blood tissue for clinical chemistry experiment.',
+        'Differential analysis, metadata, QC normalized data from human plasma tissue for clinical chemistry experiment.',
       object_zipfile:
         'bundles/motrpac_human-precovid-sed-adu_clinical-chemistry.zip',
       object_zipfile_size: '22.54 MB',
@@ -467,7 +467,7 @@ const BundleDataTypes = {
       intervention: 'Sedentary',
       study_group: 'Pre-Suspension',
       description:
-        'Summary-level results and metadata human blood tissue for clinical chemistry experiment.',
+        'Summary-level results from human plasma tissue for clinical chemistry experiment.',
       object_zipfile:
         'bundles/external/motrpac_human-presuspension-sed-adu_clinical-chemistry.zip',
       object_zipfile_size: '22.44 MB',

--- a/src/BrowseDataPage/components/bundleDataTypes.js
+++ b/src/BrowseDataPage/components/bundleDataTypes.js
@@ -381,9 +381,8 @@ const BundleDataTypes = {
       intervention: 'Sedentary',
       study_group: 'Pre-Suspension',
       description:
-        'Differential analysis, metadata, QC normalized data from human plasma tissue for clinical chemistry experiment.',
-      object_zipfile:
-        'bundles/motrpac_human-precovid-sed-adu_clinical-chemistry.zip',
+        'Differential analysis, metadata, QC normalized data from human plasma samples for clinical chemistry experiment.',
+      object_zipfile: 'bundles/motrpac_human-precovid-sed-adu_clinical-chemistry.zip',
       object_zipfile_size: '22.54 MB',
     },
   ],
@@ -467,9 +466,8 @@ const BundleDataTypes = {
       intervention: 'Sedentary',
       study_group: 'Pre-Suspension',
       description:
-        'Summary-level results from human plasma tissue for clinical chemistry experiment.',
-      object_zipfile:
-        'bundles/external/motrpac_human-presuspension-sed-adu_clinical-chemistry.zip',
+        'Summary-level results from human plasma samples for clinical chemistry experiment.',
+      object_zipfile: 'bundles/external/motrpac_human-presuspension-sed-adu_clinical-chemistry.zip',
       object_zipfile_size: '22.44 MB',
     },
   ],


### PR DESCRIPTION
This pull request adds support for a new "clinical chemistry" data type to the human pre-COVID sedentary adult phase datasets in the `BrowseDataPage` bundle data types. It also makes minor formatting adjustments to improve code consistency.

**Addition of clinical chemistry data:**

* Added a new entry for clinical chemistry data to the `human_sed_adu` bundle, including metadata and a reference to the clinical chemistry zip file (`motrpac_human-precovid-sed-adu_clinical-chemistry.zip`).
* Added a new entry for clinical chemistry data to the `human_sed_adu_external` bundle, referencing the external clinical chemistry zip file (`motrpac_human-presuspension-sed-adu_clinical-chemistry.zip`).

**Code formatting improvements:**

* Standardized the formatting of the `object_zipfile` property for epigenomics and proteomics entries by converting multi-line values to single-line values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added clinical chemistry bundle data to the browse data collection, now available in both standard and external datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->