### PR TITLE
[FIX] Game link removal

### DIFF
--- a/src/Navbar/navbar.jsx
+++ b/src/Navbar/navbar.jsx
@@ -416,9 +416,11 @@ export function Navbar({
                       <i className="material-icons dropdown-item-icon ai-icon">auto_awesome</i>
                     </Link>
                   )}
+                  {/*
                   <button type="button" className="dropdown-item" onClick={() => setGameOpen(true)}>
                     Play Game
                   </button>
+                  */}
                 </div>
               </li>
               <li className="nav-item navItem dropdown">


### PR DESCRIPTION
This pull request makes a minor change to the `Navbar` component by commenting out the "Play Game" button in the dropdown menu. No other functionality or structure is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the "Play Game" button from the Learn dropdown menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->