### PR TITLE
[BUG] Page header display fix

### DIFF
--- a/src/CodeRepoPage/codeRepoPage.jsx
+++ b/src/CodeRepoPage/codeRepoPage.jsx
@@ -160,7 +160,7 @@ export function CodeRepositories() {
             .
           </p>
         </div>
-        <div className="code-repo-content-container d-flex align-items-start justify-content-between">
+        <div className="code-repo-content-container repo-tree">
           {renderRepoComponent('Pipelines', repositories.pipelines)}
           {renderEdgeComponent()}
           {renderRepoComponent('QC', repositories.qc)}

--- a/src/MainStudy/studyAssays.jsx
+++ b/src/MainStudy/studyAssays.jsx
@@ -128,7 +128,7 @@ function StudyAssays() {
                 <span className="material-icons study-title-species-icon mr-1">pest_control_rodent</span>
                 <span>Endurance trained young adult rats study</span>
               </h3>
-              <div className="btn-group ml-3" role="group" aria-label="Assay View Select Button Group">
+              <div className="btn-group ml-md-3" role="group" aria-label="Assay View Select Button Group">
                 <button
                   type="button"
                   className={`btn btn-outline-primary btn-sm ${

--- a/src/MainStudy/studyAssays.jsx
+++ b/src/MainStudy/studyAssays.jsx
@@ -123,7 +123,7 @@ function StudyAssays() {
       <div className="study-assays-page-container">
         <div className="study-assays-page-content-container row mb-4">
           <div className="study-assays-content-container study-assays w-100">
-            <div className="col-12 d-flex align-items-center">
+            <div className="col-12 content-header">
               <h3 className="study-title-species-icon mr-1 d-flex align-items-center">
                 <span className="material-icons study-title-species-icon mr-1">pest_control_rodent</span>
                 <span>Endurance trained young adult rats study</span>

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -130,8 +130,17 @@ body.homepage {
   .relatedStudyPage,
   .searchPage,
   .teamPage,
-  .tutorialsPage {
-    padding-top: 8.50rem;
+  .tutorialsPage,
+  .exerciseBenefitsPage,
+  .dataDepositionPage,
+  .publicationsPage,
+  .mcpServerPage,
+  .knowledgeCenterPage,
+  .studyAssaysPage,
+  .glossaryPage,
+  .licensePage,
+  .citationPage {
+    padding-top: 4.0rem;
   }
 }
 

--- a/src/sass/analysisPage.scss
+++ b/src/sass/analysisPage.scss
@@ -244,3 +244,12 @@
     }
   }
 }
+
+@media (max-width: 575.98px) {
+  .graphicalClusteringPage {
+    .row {
+      padding-left: 10px;
+      padding-right: 10px;
+    }
+  }
+}

--- a/src/sass/analysisPage.scss
+++ b/src/sass/analysisPage.scss
@@ -247,9 +247,9 @@
 
 @media (max-width: 575.98px) {
   .graphicalClusteringPage {
-    .row {
-      padding-left: 10px;
-      padding-right: 10px;
+    .page-header, .graphical-clustering-container {
+      padding-left: 15px;
+      padding-right: 15px;
     }
   }
 }

--- a/src/sass/codeRepo.scss
+++ b/src/sass/codeRepo.scss
@@ -9,6 +9,13 @@
       }
     }
 
+    .repo-tree {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: flex-start;
+    }
+
     .code-repo-container {
       .component {
         border: 1px solid #ccc;
@@ -60,6 +67,25 @@
 
       img {
         width: 70%;
+      }
+    }
+  }
+}
+
+@media (max-width: 575.98px) {
+  .codeRepoPage {
+    .code-repo-content-container {
+      .repo-tree {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .code-repo-container {
+        margin-top: 2.0em;
+      }
+
+      .component-connector {
+        display: none;
       }
     }
   }

--- a/src/sass/glossary.scss
+++ b/src/sass/glossary.scss
@@ -17,3 +17,21 @@
     }
   }
 }
+
+@media (max-width: 575.98px) {
+  .glossaryPage {
+    .glossary-content-container {
+      .study-title-species-icon {
+        .material-icons {
+          display: none;
+        }
+      }
+
+      table {
+        th {
+          width: 100px;
+        }
+      }
+    }
+  }
+}

--- a/src/sass/glossary.scss
+++ b/src/sass/glossary.scss
@@ -28,8 +28,8 @@
       }
 
       table {
-        th {
-          width: 100px;
+        th:first-child {
+          min-width: 100px;
         }
       }
     }

--- a/src/sass/mainStudyPage.scss
+++ b/src/sass/mainStudyPage.scss
@@ -90,6 +90,12 @@
 
 .studyAssaysPage {
   .study-assays-page-content-container {
+    .content-header {
+      display: flex;
+      align-items: center;
+      flex-direction: row;
+    }
+
     h3 {
       background: -webkit-linear-gradient(45deg, #a64d79, #1c4587);
       -webkit-background-clip: text;
@@ -125,4 +131,22 @@
 // disable react-wordcloud tooltip
 div[data-tippy-root=""] {
   display: none !important;
+}
+
+@media (max-width: 575.98px) {
+  .studyAssaysPage {
+    .study-assays-page-content-container {
+      .content-header {
+        flex-direction: column;
+
+        h3 {
+          margin-bottom: 1.0rem;
+
+          .material-icons {
+            display: none;
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/sass/mainStudyPage.scss
+++ b/src/sass/mainStudyPage.scss
@@ -149,4 +149,11 @@ div[data-tippy-root=""] {
       }
     }
   }
+
+  .exerciseBenefitsPage {
+    .language-selector {
+      margin-left: 0;
+      margin-top: 0.5rem;
+    }
+  }
 }


### PR DESCRIPTION
This pull request introduces several UI and layout improvements for the study assays, glossary, and graphical clustering pages, with a focus on responsive design for mobile devices and consistent padding across various pages. The main changes include adjustments to headers, padding, and mobile-specific styles.

**Responsive design and mobile improvements:**

* Added mobile-specific styles for the glossary and study assays pages, such as hiding icons and adjusting table header widths in the glossary, and changing header layout and spacing in study assays for small screens.

* Introduced mobile padding for the graphical clustering page to improve appearance on small screens.

**Layout and styling consistency:**

* Standardized top padding (4rem) for multiple page types (including study assays, glossary, license, citation, etc.) to ensure consistent spacing below the header.

* Updated the study assays page header to use a new `.content-header` class for improved alignment and structure, and added corresponding styles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive design and spacing across multiple pages for small screens.
  * Header layouts updated to switch between row and column alignment based on viewport.
  * Repository view layout refined for better horizontal/vertical arrangement on different screens.
  * Table header widths constrained and decorative icons hidden on small viewports for cleaner display.
  * Reduced top padding on several pages for tighter mobile spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->