### PR TITLE
[FEATURE] Post-suspension human clinical data

### DIFF
--- a/src/BrowseDataPage/components/bundleDataTypes.js
+++ b/src/BrowseDataPage/components/bundleDataTypes.js
@@ -481,7 +481,7 @@ const BundleDataTypes = {
       intervention: '',
       study_group: 'Post-Suspension',
       description:
-        'Phenotypic data of adults and pediatrics from the main human study, including highly active cohort and ancillary studies',
+        '(Consortium Release) Adults and pediatrics phenotypic data from the main human study, including highly active cohort and ancillary studies.',
       object_zipfile:
         'bundles/motrpac_human-main_phenotype.zip',
       object_zipfile_size: '14.16 MB',

--- a/src/BrowseDataPage/components/bundleDataTypes.js
+++ b/src/BrowseDataPage/components/bundleDataTypes.js
@@ -471,6 +471,22 @@ const BundleDataTypes = {
       object_zipfile_size: '22.44 MB',
     },
   ],
+  human_main_internal: [
+    {
+      type: 'phenotype',
+      phase: 'human-main',
+      title: 'Phenotype',
+      species: 'Human',
+      participant_type: '',
+      intervention: '',
+      study_group: 'Post-Suspension',
+      description:
+        'Phenotypic data of adults and pediatrics from the main human study, including highly active cohort and ancillary studies',
+      object_zipfile:
+        'bundles/motrpac_human-main_phenotype.zip',
+      object_zipfile_size: '14.16 MB',
+    },
+  ],
 };
 
 export default BundleDataTypes;

--- a/src/BrowseDataPage/components/bundleDatasets.jsx
+++ b/src/BrowseDataPage/components/bundleDatasets.jsx
@@ -12,6 +12,7 @@ const tagColors = {
   youngAdult: 'badge-secondary',
   adult: 'badge-dark',
   preSuspension: 'badge-danger',
+  postSuspension: 'badge-danger',
   sedentary: 'badge-purple',
 };
 
@@ -95,18 +96,18 @@ function BundleDatasets({
                     {item.species}
                   </span>
                   <span
-                    className={`badge badge-pill ${item.participant_type === 'Young Adult' ? tagColors.youngAdult : tagColors.adult} mr-1`}
+                    className={`badge badge-pill ${item.participant_type.length && item.participant_type === 'Young Adult' ? tagColors.youngAdult : tagColors.adult} mr-1`}
                   >
                     {item.participant_type}
                   </span>
                   <span
-                    className={`badge badge-pill ${item.intervention === 'Endurance Training' ? tagColors.endurance : item.intervention === 'Acute Exercise' ? tagColors.acute : tagColors.sedentary} mr-1`}
+                    className={`badge badge-pill ${item.intervention.length && item.intervention === 'Endurance Training' ? tagColors.endurance : item.intervention === 'Acute Exercise' ? tagColors.acute : tagColors.sedentary} mr-1`}
                   >
                     {item.intervention}
                   </span>
                   {item.species === 'Human' && (
                     <span
-                      className={`badge badge-pill ${item.study_group === 'Pre-Suspension' ? tagColors.preSuspension : ''} mr-1`}
+                      className={`badge badge-pill ${item.study_group === 'Pre-Suspension' ? tagColors.preSuspension : tagColors.postSuspension} mr-1`}
                     >
                       {item.study_group}
                     </span>

--- a/src/BrowseDataPage/components/bundleDatasets.jsx
+++ b/src/BrowseDataPage/components/bundleDatasets.jsx
@@ -95,17 +95,21 @@ function BundleDatasets({
                   >
                     {item.species}
                   </span>
+                  {item.participant_type && item.participant_type.length && (
+                    <span
+                      className={`badge badge-pill ${item.participant_type === 'Young Adult' ? tagColors.youngAdult : tagColors.adult} mr-1`}
+                    >
+                      {item.participant_type}
+                    </span>
+                  )}
+                  {item.intervention && item.intervention.length && (
                   <span
-                    className={`badge badge-pill ${item.participant_type.length && item.participant_type === 'Young Adult' ? tagColors.youngAdult : tagColors.adult} mr-1`}
-                  >
-                    {item.participant_type}
-                  </span>
-                  <span
-                    className={`badge badge-pill ${item.intervention.length && item.intervention === 'Endurance Training' ? tagColors.endurance : item.intervention === 'Acute Exercise' ? tagColors.acute : tagColors.sedentary} mr-1`}
+                    className={`badge badge-pill ${item.intervention === 'Endurance Training' ? tagColors.endurance : item.intervention === 'Acute Exercise' ? tagColors.acute : tagColors.sedentary} mr-1`}
                   >
                     {item.intervention}
                   </span>
-                  {item.species === 'Human' && (
+                  )}
+                  {item.species === 'Human' && item.study_group && item.study_group.length && (
                     <span
                       className={`badge badge-pill ${item.study_group === 'Pre-Suspension' ? tagColors.preSuspension : tagColors.postSuspension} mr-1`}
                     >

--- a/src/BrowseDataPage/components/dataDownloadsMain.jsx
+++ b/src/BrowseDataPage/components/dataDownloadsMain.jsx
@@ -266,6 +266,21 @@ function DataDownloadsMain({
                 Acute Exercise in Humans
               </a>
             </li>
+            {userType && userType === 'internal' && (
+              <li className="nav-item font-weight-bold" role="presentation">
+                <a
+                  className="nav-link"
+                  id="human_main_bundle_datasets_tab"
+                  data-toggle="pill"
+                  href="#human_main_bundle_datasets"
+                  role="tab"
+                  aria-controls="human_main_bundle_datasets"
+                  aria-selected="false"
+                >
+                  Main Study in Humans
+                </a>
+              </li>
+            )}
           </ul>
           {/* tab panes */}
           <div className="tab-content mt-3">
@@ -322,6 +337,21 @@ function DataDownloadsMain({
                 </span>
               </div>
             </div>
+            {userType && userType === 'internal' && (
+              <div
+                className="tab-pane fade"
+                id="human_main_bundle_datasets"
+                role="tabpanel"
+                aria-labelledby="human_main_bundle_datasets_tab"
+              >
+                <BundleDatasets
+                  profile={profile}
+                  bundleDatasets={BundleDataTypes.human_main_internal}
+                  surveySubmitted={surveySubmitted}
+                  downloadedData={downloadedData}
+                />
+              </div>
+            )}
           </div>
         </div>
         {/* Additional data information */}

--- a/src/BrowseDataPage/components/dataDownloadsMain.jsx
+++ b/src/BrowseDataPage/components/dataDownloadsMain.jsx
@@ -227,7 +227,7 @@ function DataDownloadsMain({
           <ul className="nav nav-tabs" id="bundleDatasetsTab" role="tablist">
             <li className="nav-item font-weight-bold" role="presentation">
               <a
-                className="nav-link active"
+                className="nav-link"
                 id="pass1b_06_bundle_datasets_tab"
                 data-toggle="pill"
                 href="#pass1b_06_bundle_datasets"
@@ -269,7 +269,7 @@ function DataDownloadsMain({
             {userType && userType === 'internal' && (
               <li className="nav-item font-weight-bold" role="presentation">
                 <a
-                  className="nav-link"
+                  className="nav-link active"
                   id="human_main_bundle_datasets_tab"
                   data-toggle="pill"
                   href="#human_main_bundle_datasets"
@@ -285,7 +285,7 @@ function DataDownloadsMain({
           {/* tab panes */}
           <div className="tab-content mt-3">
             <div
-              className="tab-pane fade show active"
+              className="tab-pane fade"
               id="pass1b_06_bundle_datasets"
               role="tabpanel"
               aria-labelledby="pass1b_06_bundle_datasets_tab"
@@ -339,7 +339,7 @@ function DataDownloadsMain({
             </div>
             {userType && userType === 'internal' && (
               <div
-                className="tab-pane fade"
+                className="tab-pane fade show active"
                 id="human_main_bundle_datasets"
                 role="tabpanel"
                 aria-labelledby="human_main_bundle_datasets_tab"

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -47,7 +47,7 @@ export function Dashboard({
               <div className="col-md-3 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
-                    feedback
+                    cloud_download
                   </span>
                 </div>
                 <div className="feature-highlight-content mr-1">

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -53,7 +53,8 @@ export function Dashboard({
                 <div className="feature-highlight-content mr-1">
                   <h3>Main Study Clinical Data</h3>
                   <div className="data-release-text mb-3">
-                    Phenotypic data for adults and pediatrics from the main human study, including highly active cohort and ancillary studies now available for download
+                    <span className="mr-2">Adults and pediatrics phenotypic data from the main human study now available for download in bundled dataset</span>
+                    <span className="badge badge-pill badge-danger">Consortium Release</span>
                   </div>
                   <Link to="/data-download" className="btn btn-primary">Download Now</Link>
                 </div>

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -47,15 +47,15 @@ export function Dashboard({
               <div className="col-md-3 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
-                    auto_awesome
+                    feedback
                   </span>
                 </div>
                 <div className="feature-highlight-content mr-1">
-                  <h3><i>ExerWise</i> AI Assistant</h3>
+                  <h3>Main Study Clinical Data</h3>
                   <div className="data-release-text mb-3">
-                    Find answers quickly from <i>ExerWise</i>, an AI-powered assistant on topics ranging from data and study designs to processing pipelines and analysis results
+                    Phenotypic data for adults and pediatrics from the main human study, including highly active cohort and ancillary studies now available for download
                   </div>
-                  <Link to="/exerwise" className="btn btn-primary">Learn More</Link>
+                  <Link to="/data-download" className="btn btn-primary">Download Now</Link>
                 </div>
               </div>
               <div className="col-md-3 lead d-flex align-items-start">
@@ -65,11 +65,11 @@ export function Dashboard({
                   </span>
                 </div>
                 <div className="feature-highlight-content mr-1">
-                  <h3>MCP Server</h3>
+                  <h3><i>ExerWise</i> AI Assistant</h3>
                   <div className="data-release-text mb-3">
-                    Query and explore publicly released MoTrPAC datasets directly from LLM-powered clients including Claude Desktop and other supported clients
+                    Find answers quickly from <i>ExerWise</i>, an AI-powered assistant on topics ranging from data and study designs to processing pipelines and analysis results
                   </div>
-                  <Link to="/mcp-server" className="btn btn-primary">Learn More</Link>
+                  <Link to="/exerwise" className="btn btn-primary">Learn More</Link>
                 </div>
               </div>
               <div className="col-md-3 lead d-flex align-items-start">


### PR DESCRIPTION
This pull request adds support for displaying and downloading the main study clinical data for humans (phenotype data) to internal users, and updates the dashboard to highlight this new data release. It also improves badge logic and visual consistency in the dataset browsing components.

**New Human Main Study Data for Internal Users:**

* Added a new `human_main_internal` dataset entry to `BundleDataTypes` for the main human study phenotype data.
* Updated `DataDownloadsMain` to show a new tab and tab pane ("Main Study in Humans") with access to this dataset for internal users only.

**Dashboard Updates:**

* Changed the first dashboard feature highlight to announce the availability of main study clinical data, with updated icon, description, and a "Download Now" link to the data download page.
* Removed the "MCP Server" feature highlight to prioritize the new data release.

**Badge and Dataset Display Improvements:**

* Added a `postSuspension` color to `tagColors` and updated badge logic to correctly display study group badges for "Pre-Suspension" and "Post-Suspension" groups.
* Improved badge assignment logic for `participant_type` and `intervention` fields to handle empty values more robustly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Main Study in Humans" pre-bundled dataset tab (internal users)
  * Added a new Phenotype dataset (Post‑Suspension, 14.16 MB)

* **UI/Style**
  * Added Post‑Suspension badge and improved dataset tag selection logic
  * Updated dashboard highlights to feature Main Study Clinical Data
<!-- end of auto-generated comment: release notes by coderabbit.ai -->