### PR TITLE
[FIX] Data download page tab broken

### DIFF
--- a/src/BrowseDataPage/components/dataDownloadsMain.jsx
+++ b/src/BrowseDataPage/components/dataDownloadsMain.jsx
@@ -227,7 +227,7 @@ function DataDownloadsMain({
           <ul className="nav nav-tabs" id="bundleDatasetsTab" role="tablist">
             <li className="nav-item font-weight-bold" role="presentation">
               <a
-                className={`nav-link ${!userType || (userType && userType === 'external') ? 'active' : ''}`}
+                className={`nav-link ${!userType || userType === 'external' ? 'active' : ''}`}
                 id="pass1b_06_bundle_datasets_tab"
                 data-toggle="pill"
                 href="#pass1b_06_bundle_datasets"
@@ -285,7 +285,7 @@ function DataDownloadsMain({
           {/* tab panes */}
           <div className="tab-content mt-3">
             <div
-              className={`tab-pane fade ${!userType || (userType && userType === 'external') ? 'show active' : ''}`}
+              className={`tab-pane fade ${!userType || userType === 'external' ? 'show active' : ''}`}
               id="pass1b_06_bundle_datasets"
               role="tabpanel"
               aria-labelledby="pass1b_06_bundle_datasets_tab"

--- a/src/BrowseDataPage/components/dataDownloadsMain.jsx
+++ b/src/BrowseDataPage/components/dataDownloadsMain.jsx
@@ -227,7 +227,7 @@ function DataDownloadsMain({
           <ul className="nav nav-tabs" id="bundleDatasetsTab" role="tablist">
             <li className="nav-item font-weight-bold" role="presentation">
               <a
-                className="nav-link"
+                className={`nav-link ${!userType || (userType && userType === 'external') ? 'active' : ''}`}
                 id="pass1b_06_bundle_datasets_tab"
                 data-toggle="pill"
                 href="#pass1b_06_bundle_datasets"
@@ -285,7 +285,7 @@ function DataDownloadsMain({
           {/* tab panes */}
           <div className="tab-content mt-3">
             <div
-              className="tab-pane fade"
+              className={`tab-pane fade ${!userType || (userType && userType === 'external') ? 'show active' : ''}`}
               id="pass1b_06_bundle_datasets"
               role="tabpanel"
               aria-labelledby="pass1b_06_bundle_datasets_tab"


### PR DESCRIPTION
This pull request updates the logic for setting the active tab in the data downloads section based on the user's type. The changes ensure that the correct tab and tab content are set as active for external users or when the user type is not specified.

Tab activation improvements:

* The `nav-link` for the "pass1b_06_bundle_datasets_tab" tab is now set to `active` when the user is external or when no user type is specified, improving the default tab selection logic.
* The corresponding `tab-pane` for "pass1b_06_bundle_datasets" is now given the `show active` classes under the same conditions, ensuring the correct content is displayed by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Pre-bundled Data Sets" tab in the data downloads section now displays as the active tab by default for external users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->