### PR TITLE
[FIX] Rollback post-suspension clinical data consortium release

### DIFF
--- a/src/BrowseDataPage/components/dataDownloadsMain.jsx
+++ b/src/BrowseDataPage/components/dataDownloadsMain.jsx
@@ -227,7 +227,7 @@ function DataDownloadsMain({
           <ul className="nav nav-tabs" id="bundleDatasetsTab" role="tablist">
             <li className="nav-item font-weight-bold" role="presentation">
               <a
-                className={`nav-link ${!userType || userType === 'external' ? 'active' : ''}`}
+                className="nav-link active"
                 id="pass1b_06_bundle_datasets_tab"
                 data-toggle="pill"
                 href="#pass1b_06_bundle_datasets"
@@ -266,6 +266,7 @@ function DataDownloadsMain({
                 Acute Exercise in Humans
               </a>
             </li>
+            {/* Placeholder for future data releases for internal users
             {userType && userType === 'internal' && (
               <li className="nav-item font-weight-bold" role="presentation">
                 <a
@@ -281,11 +282,12 @@ function DataDownloadsMain({
                 </a>
               </li>
             )}
+            */}
           </ul>
           {/* tab panes */}
           <div className="tab-content mt-3">
             <div
-              className={`tab-pane fade ${!userType || userType === 'external' ? 'show active' : ''}`}
+              className="tab-pane fade show active"
               id="pass1b_06_bundle_datasets"
               role="tabpanel"
               aria-labelledby="pass1b_06_bundle_datasets_tab"
@@ -337,6 +339,7 @@ function DataDownloadsMain({
                 </span>
               </div>
             </div>
+            {/* Placeholder for future data releases for internal users
             {userType && userType === 'internal' && (
               <div
                 className="tab-pane fade show active"
@@ -352,6 +355,7 @@ function DataDownloadsMain({
                 />
               </div>
             )}
+            */}
           </div>
         </div>
         {/* Additional data information */}

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -44,6 +44,7 @@ export function Dashboard({
               <span>What's New</span>
             </h1>
             <div className="row">
+              {/* Placeholder for future data releases and features for internal users
               <div className="col-md-3 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
@@ -59,6 +60,7 @@ export function Dashboard({
                   <Link to="/data-download" className="btn btn-primary">Download Now</Link>
                 </div>
               </div>
+              */}
               <div className="col-md-3 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
@@ -71,6 +73,20 @@ export function Dashboard({
                     Find answers quickly from <i>ExerWise</i>, an AI-powered assistant on topics ranging from data and study designs to processing pipelines and analysis results
                   </div>
                   <Link to="/exerwise" className="btn btn-primary">Learn More</Link>
+                </div>
+              </div>
+              <div className="col-md-3 lead d-flex align-items-start">
+                <div className="feature-highlight-icon mr-3">
+                  <span className="material-icons" aria-hidden="true">
+                    auto_awesome
+                  </span>
+                </div>
+                <div className="feature-highlight-content mr-1">
+                  <h3>MCP Server</h3>
+                  <div className="data-release-text mb-3">
+                    Query and explore publicly released MoTrPAC datasets directly from LLM-powered clients including Claude Desktop and other supported clients
+                  </div>
+                  <Link to="/mcp-server" className="btn btn-primary">Learn More</Link>
                 </div>
               </div>
               <div className="col-md-3 lead d-flex align-items-start">


### PR DESCRIPTION
This pull request primarily introduces placeholders for future data releases and features aimed at internal users, while also adding back the MCP Server feature card to the dashboard. The placeholders are currently commented out and do not affect the user experience for external users.

Key changes:

**Dashboard changes:**

* Added back the "MCP Server" feature card to the dashboard, allowing users to learn about querying and exploring MoTrPAC datasets via LLM-powered clients.

**Preparation for internal user features:**

* Added commented-out placeholders in the dashboard for future data releases and features targeting internal users.
* Added commented-out placeholders in the data downloads main component for internal-only tabs and content, to support future internal data releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP Server feature card to Dashboard with navigation link

* **Changes**
  * Updated default dataset tab to "Endurance Training in Rats"
  * Restricted "Main Study in Humans" dataset access for certain users
  * Hidden "What's New" section from Dashboard

<!-- end of auto-generated comment: release notes by coderabbit.ai -->