### PR TITLE
[FIX] Biospecimen lookup viewer patch

### DIFF
--- a/src/DataExploration/Biospecimen/Clinical/components/AdvancedPagination.jsx
+++ b/src/DataExploration/Biospecimen/Clinical/components/AdvancedPagination.jsx
@@ -73,7 +73,9 @@ const AdvancedPagination = ({
             // Export current page data
             const header = 'Vial Label,Participant ID,Tranche,Temp Sample Profile,Randomized Group,Visit Code,Timepoint,Tissue,Sex,Age Groups,BMI\n';
             const rows = data.map(item =>
-              `${item.vial_label},${item.pid},${item.tranche},${item.tempSampProfile},${item.randomGroupCode},${item.visitcode},${item.timepoint},${item.sampleGroupCode},${item.sex},${item.age_groups},${item.bmi}`
+              [item.vial_label, item.pid, item.tranche, item.tempSampProfile, item.randomGroupCode, item.visitcode, item.timepoint, item.sampleGroupCode, item.sex, item.age_groups, item.bmi]
+                .map(val => val ?? '')
+                .join(',')
             ).join('\n');
             const csvData = 'data:text/csv;charset=utf-8,' + header + rows;
             const encodedUri = encodeURI(csvData);

--- a/src/DataExploration/Biospecimen/Clinical/components/AdvancedPagination.jsx
+++ b/src/DataExploration/Biospecimen/Clinical/components/AdvancedPagination.jsx
@@ -71,9 +71,9 @@ const AdvancedPagination = ({
           className="btn btn-secondary btn-sm"
           onClick={() => {
             // Export current page data
-            const header = 'Vial Label,Participant ID,Tranche,Temp Sample Profile,Randomized Group,Visit Code,Timepoint,Tissue,Sex,Age Groups,BMI,CAS Received\n';
-            const rows = data.map(item => 
-              `${item.vial_label},${item.pid},${item.tranche},${item.tempSampProfile},${item.randomGroupCode},${item.visitcode},${item.timepoint},${item.sampleGroupCode},${item.sex},${item.age_groups},${item.bmi},${item.receivedCAS}`
+            const header = 'Vial Label,Participant ID,Tranche,Temp Sample Profile,Randomized Group,Visit Code,Timepoint,Tissue,Sex,Age Groups,BMI\n';
+            const rows = data.map(item =>
+              `${item.vial_label},${item.pid},${item.tranche},${item.tempSampProfile},${item.randomGroupCode},${item.visitcode},${item.timepoint},${item.sampleGroupCode},${item.sex},${item.age_groups},${item.bmi}`
             ).join('\n');
             const csvData = 'data:text/csv;charset=utf-8,' + header + rows;
             const encodedUri = encodeURI(csvData);

--- a/src/DataExploration/Biospecimen/Clinical/components/AdvancedPagination.jsx
+++ b/src/DataExploration/Biospecimen/Clinical/components/AdvancedPagination.jsx
@@ -76,9 +76,28 @@ const AdvancedPagination = ({
             // both match Array.slice semantics after converting startIndex back to 0-based.
             const pageData = data.slice(startIndex - 1, endIndex);
             const header = 'Vial Label,Participant ID,Tranche,Temp Sample Profile,Randomized Group,Visit Code,Timepoint,Tissue,Sex,Age Group,BMI\n';
-            const rows = pageData.map(item =>
-              [item.vial_label, item.pid, transformTrancheCode(item.tranche), item.tempSampProfile, item.randomGroupCode, item.visitcode, item.timepoint, transformTissueCode(item.sampleGroupCode), item.sex, item.age_groups, item.bmi]
-                .map(val => val ?? '')
+            const toSafeCsvCell = (val) => {
+              const raw = String(val ?? '');
+              const noFormula = /^[=+\-@]/.test(raw) ? `'${raw}` : raw;
+              return /[",\n]/.test(noFormula)
+                ? `"${noFormula.replace(/"/g, '""')}"`
+                : noFormula;
+            };
+            const rows = pageData.map((item) =>
+              [
+                item.vial_label,
+                item.pid,
+                transformTrancheCode(item.tranche),
+                item.tempSampProfile,
+                item.randomGroupCode,
+                item.visitcode,
+                item.timepoint,
+                transformTissueCode(item.sampleGroupCode),
+                item.sex,
+                item.age_groups,
+                item.bmi,
+              ]
+                .map(toSafeCsvCell)
                 .join(',')
             ).join('\n');
             const csvData = 'data:text/csv;charset=utf-8,' + header + rows;

--- a/src/DataExploration/Biospecimen/Clinical/components/AdvancedPagination.jsx
+++ b/src/DataExploration/Biospecimen/Clinical/components/AdvancedPagination.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { transformTrancheCode, transformTissueCode } from '../utils/dataTransformUtils';
 
 const AdvancedPagination = ({
   data,
@@ -74,9 +75,9 @@ const AdvancedPagination = ({
             // startIndex is 1-based (display value); endIndex is the 0-based exclusive bound —
             // both match Array.slice semantics after converting startIndex back to 0-based.
             const pageData = data.slice(startIndex - 1, endIndex);
-            const header = 'Vial Label,Participant ID,Tranche,Temp Sample Profile,Randomized Group,Visit Code,Timepoint,Tissue,Sex,Age Groups,BMI\n';
+            const header = 'Vial Label,Participant ID,Tranche,Temp Sample Profile,Randomized Group,Visit Code,Timepoint,Tissue,Sex,Age Group,BMI\n';
             const rows = pageData.map(item =>
-              [item.vial_label, item.pid, item.tranche, item.tempSampProfile, item.randomGroupCode, item.visitcode, item.timepoint, item.sampleGroupCode, item.sex, item.age_groups, item.bmi]
+              [item.vial_label, item.pid, transformTrancheCode(item.tranche), item.tempSampProfile, item.randomGroupCode, item.visitcode, item.timepoint, transformTissueCode(item.sampleGroupCode), item.sex, item.age_groups, item.bmi]
                 .map(val => val ?? '')
                 .join(',')
             ).join('\n');

--- a/src/DataExploration/Biospecimen/Clinical/components/AdvancedPagination.jsx
+++ b/src/DataExploration/Biospecimen/Clinical/components/AdvancedPagination.jsx
@@ -71,8 +71,11 @@ const AdvancedPagination = ({
           className="btn btn-secondary btn-sm"
           onClick={() => {
             // Export current page data
+            // startIndex is 1-based (display value); endIndex is the 0-based exclusive bound —
+            // both match Array.slice semantics after converting startIndex back to 0-based.
+            const pageData = data.slice(startIndex - 1, endIndex);
             const header = 'Vial Label,Participant ID,Tranche,Temp Sample Profile,Randomized Group,Visit Code,Timepoint,Tissue,Sex,Age Groups,BMI\n';
-            const rows = data.map(item =>
+            const rows = pageData.map(item =>
               [item.vial_label, item.pid, item.tranche, item.tempSampProfile, item.randomGroupCode, item.visitcode, item.timepoint, item.sampleGroupCode, item.sex, item.age_groups, item.bmi]
                 .map(val => val ?? '')
                 .join(',')

--- a/src/DataExploration/Biospecimen/Clinical/components/BiospecimenResultsTable.jsx
+++ b/src/DataExploration/Biospecimen/Clinical/components/BiospecimenResultsTable.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useAdvancedPagination } from '../hooks/useAdvancedPagination';
 import AdvancedPagination from './AdvancedPagination';
-import { transformTissueCode, transformTrancheCode, transformCASReceived } from '../utils/dataTransformUtils';
+import { transformTissueCode, transformTrancheCode } from '../utils/dataTransformUtils';
 import roundNumbers from '../../../../lib/utils/roundNumbers';
 
 import '@styles/biospecimenSummary.scss';
@@ -55,7 +55,6 @@ function BiospecimenResultsTable({ data = [] }) {
               <th scope="col">Sex</th>
               <th scope="col">Age Group</th>
               <th scope="col">BMI</th>
-              <th scope="col">CAS Received</th>
             </tr>
           </thead>
           <tbody>
@@ -78,11 +77,6 @@ function BiospecimenResultsTable({ data = [] }) {
                 </td>
                 <td>{specimen.age_groups}</td>
                 <td>{roundNumbers(specimen.bmi, 1)}</td>
-                <td>
-                  <span className="badge badge-success">
-                    {Number(specimen.receivedCAS) === 1 ? 'Yes' : 'No'}
-                  </span>
-                </td>
               </tr>
             ))}
           </tbody>

--- a/src/DataExploration/Biospecimen/Clinical/components/InteractiveBiospecimenChart.jsx
+++ b/src/DataExploration/Biospecimen/Clinical/components/InteractiveBiospecimenChart.jsx
@@ -9,7 +9,7 @@ import {
   FILTER_OPTIONS,
   filterUtils,
 } from '../constants/plotOptions';
-import { transformTissueCode, transformTrancheCode, transformCASReceived } from '../utils/dataTransformUtils';
+import { transformTissueCode, transformTrancheCode } from '../utils/dataTransformUtils';
 import roundNumbers from '../../../../lib/utils/roundNumbers';
 import { getAssayFullName } from '../utils/assayCodeMapping';
 import { getStudyName } from '../utils/studyUtils';
@@ -90,7 +90,7 @@ const InteractiveBiospecimenChart = () => {
     if (!tableData || tableData.length === 0) return;
     
     // CSV header
-    const header = 'Vial Label,Participant ID,Tranche,Visit Code,Randomized Group,Tissue,Sex,Age Group,Timepoint,BMI,Temp Sample Profile,Study,CAS Received\n';
+    const header = 'Vial Label,Participant ID,Tranche,Visit Code,Randomized Group,Tissue,Sex,Age Group,Timepoint,BMI,Temp Sample Profile,Study\n';
     
     // Format a single row with all transformations
     const formatRow = (sample) => [
@@ -106,7 +106,6 @@ const InteractiveBiospecimenChart = () => {
       roundNumbers(sample.bmi, 1) || '',
       sample.temp_samp_profile || '',
       getStudyName(sample.study) || '',
-      transformCASReceived(sample.received_cas),
     ].join(',');
     
     // Generate CSV content
@@ -274,7 +273,6 @@ const InteractiveBiospecimenChart = () => {
                         <th scope="col">BMI</th>
                         <th scope="col">Temp Sample Profile</th>
                         <th scope="col">Study</th>
-                        <th scope="col">CAS Received</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -298,11 +296,6 @@ const InteractiveBiospecimenChart = () => {
                           <td>{roundNumbers(sample.bmi, 1)}</td>
                           <td>{sample.temp_samp_profile || 'N/A'}</td>
                           <td>{getStudyName(sample.study) || 'N/A'}</td>
-                          <td>
-                            <span className="badge badge-success">
-                              {transformCASReceived(sample.received_cas)}
-                            </span>
-                          </td>
                         </tr>
                       ))}
                     </tbody>

--- a/src/DataExploration/Biospecimen/Clinical/constants/plotOptions.js
+++ b/src/DataExploration/Biospecimen/Clinical/constants/plotOptions.js
@@ -83,7 +83,7 @@ export const FILTER_OPTIONS = {
   tissueOptions: ['Adipose', 'Blood', 'Muscle'],
   omeOptions: ['Epigenomic', 'Transcriptomic', 'Proteomic', 'Metabolomic'],
   studyOptions: ['Adult Sedentary', 'Adult Highly Active', 'Pediatric Low Active', 'Pediatric High Active'],
-  trancheOptions: ['Tranche 0 (PreCOVID)', 'Tranche 1', 'Tranche 2', 'Tranche 3', 'Tranche 4', 'Tranche 5', 'Not yet shipped to CAS'],
+  trancheOptions: ['Tranche 0 (PreCOVID)', 'Tranche 1', 'Tranche 2', 'Tranche 3', 'Tranche 4', 'Tranche 5'],
 };
 
 

--- a/src/DataExploration/Biospecimen/Clinical/hooks/useBiospecimenData.js
+++ b/src/DataExploration/Biospecimen/Clinical/hooks/useBiospecimenData.js
@@ -58,7 +58,7 @@ export const useBiospecimenData = () => {
         `Loaded ${response.data.length} total biospecimen records in ${(endTime - startTime).toFixed(2)}ms`
       );
       
-      setAllData(response.data.filter(item => item.raw_assays_with_results != null));
+      setAllData((response?.data || []).filter(item => item?.raw_assays_with_results != null));
       setLoading(false);
     } catch (err) {
       // Handle cancellation - don't update state if request was cancelled

--- a/src/DataExploration/Biospecimen/Clinical/hooks/useBiospecimenData.js
+++ b/src/DataExploration/Biospecimen/Clinical/hooks/useBiospecimenData.js
@@ -58,7 +58,7 @@ export const useBiospecimenData = () => {
         `Loaded ${response.data.length} total biospecimen records in ${(endTime - startTime).toFixed(2)}ms`
       );
       
-      setAllData(response.data);
+      setAllData(response.data.filter(item => item.raw_assays_with_results != null));
       setLoading(false);
     } catch (err) {
       // Handle cancellation - don't update state if request was cancelled

--- a/src/DataExploration/Biospecimen/Clinical/summaryStatistics.jsx
+++ b/src/DataExploration/Biospecimen/Clinical/summaryStatistics.jsx
@@ -25,8 +25,9 @@ function ClinicalBiospecimenSummaryStatistics() {
         <span>Biospecimen Lookup</span>
       </h1>
       <div className="lead mb-4">
-        Use this tool to look up clinical biospecimen data curated from human
-        adults and pediatrics across multiple interventions, timepoints and assays.
+        This tool summarizes participants and samples with biomolecular data at the
+        bioinformatics center. It does not reflect all enrollees nor does it reflect
+        all collected biosamples.
       </div>
       <div className="biospecimen-lookup-container mb-4">
         {/* Interactive Biospecimen Chart Component - handles all filtering and visualization */}

--- a/src/DataExploration/Biospecimen/Clinical/utils/dataTransformUtils.js
+++ b/src/DataExploration/Biospecimen/Clinical/utils/dataTransformUtils.js
@@ -40,15 +40,6 @@ export const transformTrancheCode = (code) => {
 };
 
 /**
- * Transform received_cas code to Yes/No
- * @param {number|string} value - CAS received value (typically 0 or 1)
- * @returns {string} 'Yes' or 'No'
- */
-export const transformCASReceived = (value) => {
-  return Number(value) === 1 ? 'Yes' : 'No';
-};
-
-/**
  * Get all available tranche codes
  * @returns {Array<string>} Array of tranche codes
  */


### PR DESCRIPTION
This pull request removes the "CAS Received" field from the biospecimen clinical data UI, including all related table columns, CSV exports, and transformation utilities. It also makes a minor adjustment to the available tranche options and filters out biospecimen records with missing assay results.

**Removal of "CAS Received" field:**

- Removed the "CAS Received" column from all relevant tables in `BiospecimenResultsTable` and `InteractiveBiospecimenChart` components, as well as from their CSV export headers and data rows.
- Removed the `transformCASReceived` utility function and its imports from the codebase.

**Data filtering and options update:**

- Updated the data loading hook to exclude biospecimen records that are missing assay results (`raw_assays_with_results == null`).
- Removed "Not yet shipped to CAS" from the list of available tranche options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Removed "CAS Received" column from biospecimen tables and CSV exports; renamed "Age Groups" header to "Age Group".
  * CSV exports now include only the currently visible page, normalize tranche/tissue labels, and sanitize cell values to prevent mis-parsing or formula injection.

* **Filter Options**
  * Removed "Not yet shipped to CAS" from the tranche dropdown.

* **Data Processing**
  * Initial load now shows only biospecimens with available assay results.

* **Documentation**
  * Updated lead paragraph copy to clarify scope of summarized samples and participants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->