### PR TITLE
[FEATURE] Consortium release of Mars papers clinical data

### DIFF
--- a/src/BrowseDataPage/components/bundleDataTypes.js
+++ b/src/BrowseDataPage/components/bundleDataTypes.js
@@ -471,20 +471,34 @@ const BundleDataTypes = {
       object_zipfile_size: '22.44 MB',
     },
   ],
-  human_main_internal: [
+  human_clinical_data_internal: [
     {
       type: 'phenotype',
       phase: 'human-main',
-      title: 'Phenotype',
+      title: 'Post-Suspension Sedentary Adults (Consortium Release)',
       species: 'Human',
-      participant_type: '',
-      intervention: '',
+      participant_type: 'Adult',
+      intervention: 'Sedentary',
       study_group: 'Post-Suspension',
       description:
-        '(Consortium Release) Adults and pediatrics phenotypic data from the main human study, including highly active cohort and ancillary studies.',
+        'Post-suspension sedentary human adults phenotypic data, excluding highly active cohort and ancillary studies.',
       object_zipfile:
-        'bundles/motrpac_human-main_phenotype.zip',
-      object_zipfile_size: '14.16 MB',
+        'bundles/motrpac_human-main-sed-adu_phenotype.zip',
+      object_zipfile_size: '3.9 MB',
+    },
+    {
+      type: 'phenotype',
+      phase: 'human-all',
+      title: 'Low Active Pediatrics (Consortium Release)',
+      species: 'Human',
+      participant_type: 'Pediatric',
+      intervention: 'Low Active',
+      study_group: 'Pre- & Post-Suspension',
+      description:
+        'Low active pediatrics phenotypic data, excluding highly active cohort and ancillary studies.',
+      object_zipfile:
+        'bundles/motrpac_human-all-ped_phenotype.zip',
+      object_zipfile_size: '467.8 KB',
     },
   ],
 };

--- a/src/BrowseDataPage/components/bundleDatasets.jsx
+++ b/src/BrowseDataPage/components/bundleDatasets.jsx
@@ -97,7 +97,7 @@ function BundleDatasets({
                   </span>
                   {item.participant_type && item.participant_type.length && (
                     <span
-                      className={`badge badge-pill ${item.participant_type === 'Young Adult' ? tagColors.youngAdult : tagColors.adult} mr-1`}
+                      className={`badge badge-pill ${item.participant_type === 'Young Adult' || item.participant_type === 'Pediatric' ? tagColors.youngAdult : tagColors.adult} mr-1`}
                     >
                       {item.participant_type}
                     </span>

--- a/src/BrowseDataPage/components/dataDownloadsMain.jsx
+++ b/src/BrowseDataPage/components/dataDownloadsMain.jsx
@@ -233,7 +233,7 @@ function DataDownloadsMain({
                 href="#pass1b_06_bundle_datasets"
                 role="tab"
                 aria-controls="pass1b_06_bundle_datasets"
-                aria-selected="true"
+                aria-selected={!userType || userType === 'external' ? 'true' : 'false'}
               >
                 Endurance Training in Rats
               </a>
@@ -275,7 +275,7 @@ function DataDownloadsMain({
                   href="#human_clinical_data_bundle_datasets"
                   role="tab"
                   aria-controls="human_clinical_data_bundle_datasets"
-                  aria-selected="false"
+                  aria-selected="true"
                 >
                   Clinical Data in Humans
                 </a>
@@ -355,9 +355,10 @@ function DataDownloadsMain({
                     <i className="bi bi-file-earmark-fill mr-2 text-primary" />
                     <span>
                       Learn more about the sedentary adults (post-suspension) and low active pediatrics clinical data in the{' '}
-                      <a href="https://docs.google.com/document/d/1cFPnB1cBKimUJo-5hwnq8yKDJ5DWgdDj4Y0pvl2UZYw/edit?tab=t.0#heading=h.7tm379xtz7sk" target="_blank" rel="noopener noreferrer">
-                        Clinical Data Release Notes
-                      </a>
+                      <ExternalLink
+                        to="https://docs.google.com/document/d/1cFPnB1cBKimUJo-5hwnq8yKDJ5DWgdDj4Y0pvl2UZYw/edit?tab=t.0#heading=h.7tm379xtz7sk"
+                        label="Clinical Data Release Notes"
+                      />
                     </span>
                   </span>
                 </div>

--- a/src/BrowseDataPage/components/dataDownloadsMain.jsx
+++ b/src/BrowseDataPage/components/dataDownloadsMain.jsx
@@ -227,7 +227,7 @@ function DataDownloadsMain({
           <ul className="nav nav-tabs" id="bundleDatasetsTab" role="tablist">
             <li className="nav-item font-weight-bold" role="presentation">
               <a
-                className="nav-link active"
+                className={`nav-link ${!userType || userType === 'external' ? 'active' : ''}`}
                 id="pass1b_06_bundle_datasets_tab"
                 data-toggle="pill"
                 href="#pass1b_06_bundle_datasets"
@@ -266,28 +266,26 @@ function DataDownloadsMain({
                 Acute Exercise in Humans
               </a>
             </li>
-            {/* Placeholder for future data releases for internal users
             {userType && userType === 'internal' && (
               <li className="nav-item font-weight-bold" role="presentation">
                 <a
                   className="nav-link active"
-                  id="human_main_bundle_datasets_tab"
+                  id="human_clinical_data_bundle_datasets_tab"
                   data-toggle="pill"
-                  href="#human_main_bundle_datasets"
+                  href="#human_clinical_data_bundle_datasets"
                   role="tab"
-                  aria-controls="human_main_bundle_datasets"
+                  aria-controls="human_clinical_data_bundle_datasets"
                   aria-selected="false"
                 >
-                  Main Study in Humans
+                  Clinical Data in Humans
                 </a>
               </li>
             )}
-            */}
           </ul>
           {/* tab panes */}
           <div className="tab-content mt-3">
             <div
-              className="tab-pane fade show active"
+              className={`tab-pane fade ${!userType || userType === 'external' ? 'show active' : ''}`}
               id="pass1b_06_bundle_datasets"
               role="tabpanel"
               aria-labelledby="pass1b_06_bundle_datasets_tab"
@@ -339,23 +337,21 @@ function DataDownloadsMain({
                 </span>
               </div>
             </div>
-            {/* Placeholder for future data releases for internal users
             {userType && userType === 'internal' && (
               <div
                 className="tab-pane fade show active"
-                id="human_main_bundle_datasets"
+                id="human_clinical_data_bundle_datasets"
                 role="tabpanel"
-                aria-labelledby="human_main_bundle_datasets_tab"
+                aria-labelledby="human_clinical_data_bundle_datasets_tab"
               >
                 <BundleDatasets
                   profile={profile}
-                  bundleDatasets={BundleDataTypes.human_main_internal}
+                  bundleDatasets={BundleDataTypes.human_clinical_data_internal}
                   surveySubmitted={surveySubmitted}
                   downloadedData={downloadedData}
                 />
               </div>
             )}
-            */}
           </div>
         </div>
         {/* Additional data information */}

--- a/src/BrowseDataPage/components/dataDownloadsMain.jsx
+++ b/src/BrowseDataPage/components/dataDownloadsMain.jsx
@@ -350,6 +350,17 @@ function DataDownloadsMain({
                   surveySubmitted={surveySubmitted}
                   downloadedData={downloadedData}
                 />
+                <div className="bd-callout bd-callout-primary mt-3">
+                  <span className="font-weight-bold">
+                    <i className="bi bi-file-earmark-fill mr-2 text-primary" />
+                    <span>
+                      Learn more about the sedentary adults (post-suspension) and low active pediatrics clinical data in the{' '}
+                      <a href="https://docs.google.com/document/d/1cFPnB1cBKimUJo-5hwnq8yKDJ5DWgdDj4Y0pvl2UZYw/edit?tab=t.0#heading=h.7tm379xtz7sk" target="_blank" rel="noopener noreferrer">
+                        Clinical Data Release Notes
+                      </a>
+                    </span>
+                  </span>
+                </div>
               </div>
             )}
           </div>

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -44,7 +44,6 @@ export function Dashboard({
               <span>What's New</span>
             </h1>
             <div className="row">
-              {/* Placeholder for future data releases and features for internal users
               <div className="col-md-3 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
@@ -52,15 +51,14 @@ export function Dashboard({
                   </span>
                 </div>
                 <div className="feature-highlight-content mr-1">
-                  <h3>Main Study Clinical Data</h3>
+                  <h3>Human Clinical Data</h3>
                   <div className="data-release-text mb-3">
-                    <span className="mr-2">Adults and pediatrics phenotypic data from the main human study now available for download in bundled dataset</span>
+                    <span className="mr-2">Sedentary adults (post-suspension) and low active pediatrics phenotypic data now available for download in bundled datasets</span>
                     <span className="badge badge-pill badge-danger">Consortium Release</span>
                   </div>
-                  <Link to="/data-download" className="btn btn-primary">Download Now</Link>
+                  <Link to="/data-download" className="btn btn-primary">Download Datasets</Link>
                 </div>
               </div>
-              */}
               <div className="col-md-3 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
@@ -73,20 +71,6 @@ export function Dashboard({
                     Find answers quickly from <i>ExerWise</i>, an AI-powered assistant on topics ranging from data and study designs to processing pipelines and analysis results
                   </div>
                   <Link to="/exerwise" className="btn btn-primary">Learn More</Link>
-                </div>
-              </div>
-              <div className="col-md-3 lead d-flex align-items-start">
-                <div className="feature-highlight-icon mr-3">
-                  <span className="material-icons" aria-hidden="true">
-                    auto_awesome
-                  </span>
-                </div>
-                <div className="feature-highlight-content mr-1">
-                  <h3>MCP Server</h3>
-                  <div className="data-release-text mb-3">
-                    Query and explore publicly released MoTrPAC datasets directly from LLM-powered clients including Claude Desktop and other supported clients
-                  </div>
-                  <Link to="/mcp-server" className="btn btn-primary">Learn More</Link>
                 </div>
               </div>
               <div className="col-md-3 lead d-flex align-items-start">


### PR DESCRIPTION
This pull request updates the internal clinical data bundles for human studies, improves the user interface for internal users, and updates the dashboard to reflect the latest data releases. The most important changes are summarized below:

**Clinical Data Bundles & Internal Data Updates:**

* Renamed the `human_main_internal` bundle to `human_clinical_data_internal` in `bundleDataTypes.js`, and replaced the previous "Phenotype" entry with two new datasets: "Post-Suspension Sedentary Adults" and "Low Active Pediatrics", each with updated descriptions, participant types, interventions, and download links.

**User Interface Improvements for Internal Users:**

* Updated the data downloads page to show a new "Clinical Data in Humans" tab for internal users, replacing the old "Main Study in Humans" tab, and adjusted the tab logic to properly handle active states for internal and external users.
* Updated the tab content for internal users to display the new clinical data bundles and added a callout with a link to the Clinical Data Release Notes for more information.

**Dashboard Updates:**

* Updated the dashboard's "What's New" section to announce the availability of the new clinical data bundles, with revised text and button labels for clarity.
* Removed the "MCP Server" feature highlight from the dashboard for internal users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Clinical data downloads now available with separate datasets for post-suspension sedentary adults and low-active pediatrics, each with detailed participant and intervention information
* New "Clinical Data in Humans" tab added to the data downloads interface
* Updated dashboard with Human Clinical Data download card for quick access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->