### PR TITLE
[PATCH] Temporary hold on releasing MARS paper clinical data

### DIFF
--- a/src/BrowseDataPage/components/dataDownloadsMain.jsx
+++ b/src/BrowseDataPage/components/dataDownloadsMain.jsx
@@ -344,6 +344,7 @@ function DataDownloadsMain({
                 role="tabpanel"
                 aria-labelledby="human_clinical_data_bundle_datasets_tab"
               >
+                {/*
                 <BundleDatasets
                   profile={profile}
                   bundleDatasets={BundleDataTypes.human_clinical_data_internal}
@@ -362,6 +363,8 @@ function DataDownloadsMain({
                     </span>
                   </span>
                 </div>
+                */}
+                <span className="font-weight-bold">Coming soon</span>
               </div>
             )}
           </div>

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -44,6 +44,7 @@ export function Dashboard({
               <span>What's New</span>
             </h1>
             <div className="row">
+              {/*
               <div className="col-md-3 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
@@ -59,7 +60,8 @@ export function Dashboard({
                   <Link to="/data-download" className="btn btn-primary">Download Datasets</Link>
                 </div>
               </div>
-              <div className="col-md-3 lead d-flex align-items-start">
+              */}
+              <div className="col-md-4 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
                     auto_awesome
@@ -73,7 +75,7 @@ export function Dashboard({
                   <Link to="/exerwise" className="btn btn-primary">Learn More</Link>
                 </div>
               </div>
-              <div className="col-md-3 lead d-flex align-items-start">
+              <div className="col-md-4 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
                     auto_stories
@@ -87,7 +89,7 @@ export function Dashboard({
                   <Link to="/knowledge-center" className="btn btn-primary">Learn More</Link>
                 </div>
               </div>
-              <div className="col-md-3 lead d-flex align-items-start">
+              <div className="col-md-4 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
                     insights


### PR DESCRIPTION
This pull request primarily updates the Dashboard and Data Downloads Main components to temporarily hide the MARS paper clinical data release. The most significant changes involve commenting out sections related to clinical data availability and adding "Coming soon" messaging, as well as adjusting the layout of feature highlight cards on the Dashboard.