### PR TITLE
[PATCH] Rolled back temporary hold changes

### DIFF
--- a/src/BrowseDataPage/components/dataDownloadsMain.jsx
+++ b/src/BrowseDataPage/components/dataDownloadsMain.jsx
@@ -344,7 +344,6 @@ function DataDownloadsMain({
                 role="tabpanel"
                 aria-labelledby="human_clinical_data_bundle_datasets_tab"
               >
-                {/*
                 <BundleDatasets
                   profile={profile}
                   bundleDatasets={BundleDataTypes.human_clinical_data_internal}
@@ -363,8 +362,6 @@ function DataDownloadsMain({
                     </span>
                   </span>
                 </div>
-                */}
-                <span className="font-weight-bold">Coming soon</span>
               </div>
             )}
           </div>

--- a/src/Dashboard/dashboard.jsx
+++ b/src/Dashboard/dashboard.jsx
@@ -44,7 +44,6 @@ export function Dashboard({
               <span>What's New</span>
             </h1>
             <div className="row">
-              {/*
               <div className="col-md-3 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
@@ -60,8 +59,7 @@ export function Dashboard({
                   <Link to="/data-download" className="btn btn-primary">Download Datasets</Link>
                 </div>
               </div>
-              */}
-              <div className="col-md-4 lead d-flex align-items-start">
+              <div className="col-md-3 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
                     auto_awesome
@@ -75,7 +73,7 @@ export function Dashboard({
                   <Link to="/exerwise" className="btn btn-primary">Learn More</Link>
                 </div>
               </div>
-              <div className="col-md-4 lead d-flex align-items-start">
+              <div className="col-md-3 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
                     auto_stories
@@ -89,7 +87,7 @@ export function Dashboard({
                   <Link to="/knowledge-center" className="btn btn-primary">Learn More</Link>
                 </div>
               </div>
-              <div className="col-md-4 lead d-flex align-items-start">
+              <div className="col-md-3 lead d-flex align-items-start">
                 <div className="feature-highlight-icon mr-3">
                   <span className="material-icons" aria-hidden="true">
                     insights


### PR DESCRIPTION
Rolled back minor UI changes in prior PR and lift the hold on releasing clinical data to consortium.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled "Human Clinical Data" card visibility for internal users in the What's New section.

* **Updates**
  * Adjusted feature highlight cards layout to display in a 4-column grid for better spacing.
  * Clinical Data in Humans section now displays a "Coming soon" placeholder message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->