### PR TITLE
[BUG] Fix nested token restoration in fetch-docs

### DIFF
--- a/scripts/fetch-docs.js
+++ b/scripts/fetch-docs.js
@@ -752,13 +752,20 @@ function fixBrandNamesInPlainTextOnly(text) {
   // do-while loop in removeHtmlComments.
   let result = masked;
   let previous;
+  let restorationPasses = 0;
+  const maxRestorationPasses = patterns.length + 1;
+
   do {
     previous = result;
     result = result.replace(/__KB_PROTECTED_(\d+)__/g, (_, idx) => {
       const tokenIndex = Number(idx);
       return protectedTokens[tokenIndex] ?? "";
     });
+    if (result !== previous && ++restorationPasses > maxRestorationPasses) {
+      throw new Error("Protected-token restoration did not converge");
+    }
   } while (result !== previous);
+
   return result;
 }
 

--- a/scripts/fetch-docs.js
+++ b/scripts/fetch-docs.js
@@ -745,10 +745,21 @@ function fixBrandNamesInPlainTextOnly(text) {
 
   masked = fixBrandNames(masked);
 
-  return masked.replace(/__KB_PROTECTED_(\d+)__/g, (_, idx) => {
-    const tokenIndex = Number(idx);
-    return protectedTokens[tokenIndex] || "";
-  });
+  // Restore protected tokens. A later pattern (e.g. markdown links) can end up
+  // wrapping text that an earlier pattern already masked (e.g. inline code
+  // used as a link's label), producing a token whose stored original still
+  // contains another token. Repeat the restore until stable, mirroring the
+  // do-while loop in removeHtmlComments.
+  let result = masked;
+  let previous;
+  do {
+    previous = result;
+    result = result.replace(/__KB_PROTECTED_(\d+)__/g, (_, idx) => {
+      const tokenIndex = Number(idx);
+      return protectedTokens[tokenIndex] ?? "";
+    });
+  } while (result !== previous);
+  return result;
 }
 
 /** Clean up markdown: strip comments, HTML tags, fix whitespace, fix brands. */


### PR DESCRIPTION
Restore protected markdown tokens in a loop until the text stabilizes so nested placeholders are fully resolved. This fixes cases where later masking steps wrap earlier protected content, such as inline code used inside markdown links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text processing to correctly restore nested protected content.
  * Preserved handling for missing placeholders by replacing them with empty text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->